### PR TITLE
Site picker: tap a dot opens a choice popup (Explore | About), no auto-load

### DIFF
--- a/server.R
+++ b/server.R
@@ -170,10 +170,110 @@ server <- function(input, output, session) {
     session$sendCustomMessage("smtLoadStart", list(label = sprintf("%s — %s", code, nm)))
     load_site(code, s0, e0, FALSE)
   }
+  # ---- the site-choice popup + "About this site" card --------------------
+  # Tapping a dot no longer auto-loads. It opens a small popup anchored on the
+  # dot offering a CLEAR choice: "Explore this site" (loads the record) or
+  # "About this site" (an instant info card). Both built from SITE_INDEX by the
+  # clicked code, so they're identical in by-site and by-species mode.
+  site_popup_html <- function(row) {
+    code <- row$site[1]
+    where <- paste(stats::na.omit(c(
+      as.character(row$state[1]),
+      if (!is.na(row$domain[1])) paste("NEON", row$domain[1]) else NA,
+      as.character(row$bio[1]))), collapse = " · ")
+    sp_line <- if (!is.na(row$top_species[1]))
+      sprintf("<div class='pm-pop-sp'>Most caught: <i>%s</i>%s</div>", row$top_species[1],
+              if (!is.na(row$nickname[1])) sprintf(" (%s)", row$nickname[1]) else "") else ""
+    yrs <- if (!is.na(row$year_min[1]) && !is.na(row$year_max[1]))
+      sprintf("<div class='sp-years'>Sampled %d&ndash;%d</div>", row$year_min[1], row$year_max[1]) else ""
+    htmltools::HTML(sprintf(
+      "<div class='pm-pop site-pop'>
+         <div class='pm-pop-t'>%s %s <span class='sp-code'>(%s)</span></div>
+         <div class='pm-pop-s'>%s</div>
+         <div class='pm-pop-n'><b>%s</b> captures &middot; <b>%s</b> individuals &middot; <b>%s</b> species</div>
+         %s%s
+         <div class='sp-actions'>
+           <button type='button' class='sp-btn sp-go' onclick=\"Shiny.setInputValue('siteExplore','%s',{priority:'event'});\">Explore this site &rarr;</button>
+           <button type='button' class='sp-btn sp-info' onclick=\"Shiny.setInputValue('siteInfo','%s',{priority:'event'});\">About this site</button>
+         </div>
+       </div>",
+      row$emoji[1], row$name[1], code, where,
+      format(row$captures[1], big.mark = ","), format(row$individuals[1], big.mark = ","),
+      row$species[1], sp_line, yrs, code, code))
+  }
+
+  site_info_modal <- function(code) {
+    row <- if (!is.null(SITE_INDEX)) SITE_INDEX[SITE_INDEX$site == code, ] else NULL
+    if (is.null(row) || !nrow(row))
+      return(modalDialog(title = "Site info", easyClose = TRUE, footer = modalButton("Close"),
+                         p("No details are available for this site.")))
+    dash  <- function(x) if (length(x) == 0 || is.na(x) || !nzchar(as.character(x))) "—" else as.character(x)
+    coords <- if (!is.na(row$lat[1]) && !is.na(row$lng[1]))
+      sprintf("%.3f, %.3f", row$lat[1], row$lng[1]) else "—"
+    yrs <- if (!is.na(row$year_min[1]) && !is.na(row$year_max[1]))
+      sprintf("%d–%d", row$year_min[1], row$year_max[1]) else "—"
+    star <- if (!is.na(row$top_species[1]))
+      HTML(sprintf("<i>%s</i>%s%s", row$top_species[1],
+        if (!is.na(row$nickname[1])) sprintf(" (%s)", row$nickname[1]) else "",
+        if (!is.na(row$top_caps[1])) sprintf(" — %s captures", format(row$top_caps[1], big.mark = ",")) else ""))
+      else "—"
+    stat <- function(v, lab) div(class = "si-stat",
+      div(class = "si-stat-n", if (is.na(v)) "—" else format(v, big.mark = ",")),
+      div(class = "si-stat-l", lab))
+    modalDialog(
+      title = HTML(sprintf("%s %s <span class='si-code'>(%s)</span>", row$emoji[1], row$name[1], code)),
+      easyClose = TRUE, size = "m",
+      footer = tagList(
+        modalButton("Close"),
+        tags$button(type = "button", class = "btn btn-primary",
+          onclick = sprintf("Shiny.setInputValue('siteExplore','%s',{priority:'event'});", code),
+          HTML("Explore this site&rsquo;s data &rarr;"))),
+      div(class = "site-info",
+        div(class = "si-sec",
+          div(class = "si-h", "Where"),
+          div(class = "si-row", dash(row$state[1]), " · NEON ", dash(row$domain[1])),
+          if (!is.na(row$bio[1])) div(class = "si-row si-bio", row$bio[1]),
+          div(class = "si-coords", bs_icon("geo-alt"), " ", coords)),
+        div(class = "si-sec",
+          div(class = "si-h", "When"),
+          div(class = "si-row", "Sampled ", yrs)),
+        div(class = "si-sec",
+          div(class = "si-h", "What’s been caught"),
+          div(class = "si-stats",
+            stat(row$captures[1], "captures"),
+            stat(row$individuals[1], "individuals"),
+            stat(row$species[1], "species")),
+          div(class = "si-row si-star", "Most caught: ", star)),
+        div(class = "si-sec",
+          div(class = "si-h", "Ecological family"),
+          div(class = "si-row si-fam",
+            tags$span(class = "si-dot", style = sprintf("background:%s", dash(row$group_color[1]))),
+            dash(row$group_label[1])))))
+  }
+
+  # click a dot -> open the choice popup (clearPopups first = one popup, ever)
   observeEvent(input$pickerMap_marker_click, {
-    click <- input$pickerMap_marker_click
-    if (!is.null(click$id)) load_site_full(click$id)
+    code <- input$pickerMap_marker_click$id
+    if (is.null(code) || is.na(code)) return()
+    row <- if (!is.null(SITE_INDEX)) SITE_INDEX[SITE_INDEX$site == code, ] else NULL
+    if (is.null(row) || !nrow(row)) { load_site_full(code); return() }  # fallback
+    leaflet::leafletProxy("pickerMap") %>% leaflet::clearPopups() %>%
+      leaflet::addPopups(lng = row$lng[1], lat = row$lat[1], popup = site_popup_html(row),
+        layerId = paste0("pop_", code),
+        options = leaflet::popupOptions(maxWidth = 300, minWidth = 230, autoPan = TRUE,
+          autoPanPadding = c(40, 55), keepInView = TRUE, closeButton = TRUE,
+          closeOnClick = FALSE, className = "pm-pop-card"))
   })
+  # "Explore this site" (popup button OR About-modal footer button) -> load it.
+  # removeModal()/clearPopups() so neither floats over the loading overlay.
+  observeEvent(input$siteExplore, {
+    removeModal()
+    leaflet::leafletProxy("pickerMap") %>% leaflet::clearPopups()
+    load_site_full(input$siteExplore)
+  })
+  # "About this site" -> instant info card (no bundle load)
+  observeEvent(input$siteInfo, showModal(site_info_modal(input$siteInfo)))
+
   observeEvent(input$pickFromList, load_site_full(input$pickFromList))
 
   # "Change site" (in the hero band) -> back to the picker-map landing
@@ -340,15 +440,12 @@ server <- function(input, output, session) {
   # add the all-sites markers (by-site mode): size = captures, color = family
   add_site_markers <- function(map) {
     idx <- SITE_INDEX
+    # hover label = a quick name-tag only; the CLICK opens the choice popup
     labs <- lapply(seq_len(nrow(idx)), function(i) htmltools::HTML(sprintf(
       "<div class='pm-pop'><div class='pm-pop-t'>%s %s</div>
-       <div class='pm-pop-s'>%s, %s · NEON %s</div>
-       <div class='pm-pop-n'><b>%s</b> captures · <b>%s</b> individuals · <b>%s</b> species</div>
-       <div class='pm-pop-sp'>Most caught: <i>%s</i></div>
-       <div class='pm-pop-go'>Click to explore &rarr;</div></div>",
-      idx$emoji[i], idx$site[i], idx$name[i], idx$state[i], idx$domain[i],
-      format(idx$captures[i], big.mark = ","), format(idx$individuals[i], big.mark = ","),
-      idx$species[i], idx$top_species[i])))
+       <div class='pm-pop-s'>%s · %s</div>
+       <div class='pm-pop-hint'>Tap for site options</div></div>",
+      idx$emoji[i], idx$site[i], idx$name[i], idx$state[i])))
     leaflet::addCircleMarkers(map, data = idx, lng = ~lng, lat = ~lat, layerId = ~site,
       radius = picker_radius(idx$captures), stroke = TRUE, color = "#ffffff", weight = 1.5,
       opacity = 1, fillColor = ~group_color, fillOpacity = 0.85, label = labs,
@@ -365,7 +462,7 @@ server <- function(input, output, session) {
       "<div class='pm-pop'><div class='pm-pop-t'>%s %s</div>
        <div class='pm-pop-s'>%s, %s</div>
        <div class='pm-pop-n'><b>%s</b> individuals · <b>%s</b> captures here</div>
-       <div class='pm-pop-go'>Click to open this site &rarr;</div></div>",
+       <div class='pm-pop-hint'>Tap for site options</div></div>",
       r$emoji[i], r$site[i], r$name[i], r$state[i],
       format(r$individuals[i], big.mark = ","), format(r$captures[i], big.mark = ","))))
     leaflet::addCircleMarkers(map, data = r, lng = ~lng, lat = ~lat, layerId = ~site,
@@ -386,7 +483,7 @@ server <- function(input, output, session) {
   # swap markers when the user toggles mode or picks a species (proxy = no reflow)
   observeEvent(list(input$pickMode, input$rangeSpecies), {
     req(SITE_INDEX)
-    map <- leaflet::leafletProxy("pickerMap") %>% leaflet::clearMarkers()
+    map <- leaflet::leafletProxy("pickerMap") %>% leaflet::clearMarkers() %>% leaflet::clearPopups()
     if (identical(input$pickMode, "species") && !is.null(input$rangeSpecies) &&
         nzchar(input$rangeSpecies)) {
       add_species_markers(map, input$rangeSpecies)

--- a/www/app.js
+++ b/www/app.js
@@ -136,9 +136,9 @@ function smtTour() {
   var D = window.driver.js.driver;
   var steps = [
     { element: ".picker-mode", popover: { title: "Two ways in", side: "bottom",
-        description: "Explore <b>by site</b> — tap a dot to open it — or switch to <b>by species</b> to map where one animal turns up across the country." } },
+        description: "Explore <b>by site</b> — tap a dot for its card — or switch to <b>by species</b> to map where one animal turns up across the country." } },
     { element: ".picker-map-wrap", popover: { title: "The national map", side: "top",
-        description: "Every NEON site is a dot — <b>bigger</b> = more animals caught, <b>color</b> = the family of the most-common species there. Click any dot to dive in." } },
+        description: "Every NEON site is a dot — <b>bigger</b> = more animals caught, <b>color</b> = the family of the most-common species there. Tap any dot to see its card, then choose <b>Explore</b> or <b>About</b>." } },
     { element: "#compareBtn", popover: { title: "Compare two sites", side: "top",
         description: "Put two sites head-to-head — species, diversity, and abundance, side by side." } },
     { element: "#demoBtn2", popover: { title: "In a hurry?", side: "top",

--- a/www/styles.css
+++ b/www/styles.css
@@ -246,7 +246,43 @@ table.dataTable td, table.dataTable th { border-color: #eef1ec !important; color
 .pm-pop-s { color: var(--muted); font-size: 11.5px; margin-top: 1px; }
 .pm-pop-n { font-size: 12px; color: var(--ink); margin-top: 5px; }
 .pm-pop-sp { font-size: 12px; color: var(--pine); margin-top: 2px; }
-.pm-pop-go { font-size: 11.5px; font-weight: 700; color: var(--terra); margin-top: 6px; }
+.pm-pop-hint { font-size: 11px; font-weight: 700; color: var(--sky); margin-top: 6px;
+  text-transform: uppercase; letter-spacing: .4px; }
+
+/* ---- site-choice popup (tap a dot -> Explore | About) ----------------- */
+.pm-pop-card .leaflet-popup-content-wrapper { border-radius: 14px; box-shadow: 0 12px 36px rgba(12,35,75,.24); }
+.pm-pop-card .leaflet-popup-content { margin: 12px 14px; }
+.site-pop { min-width: 210px; }
+.site-pop .sp-code { color: var(--muted); font-weight: 700; }
+.site-pop .sp-years { font-size: 11.5px; color: var(--muted); margin-top: 4px; }
+.sp-actions { display: flex; flex-direction: column; gap: 7px; margin-top: 11px; }
+.sp-btn { display: block; width: 100%; min-height: 42px; border-radius: 10px; font-weight: 700;
+  font-size: 13.5px; cursor: pointer; border: 1.5px solid transparent; padding: 8px 12px;
+  transition: transform .12s ease, box-shadow .12s ease, background .12s ease; }
+.sp-btn:hover { transform: translateY(-1px); }
+.sp-go { background: var(--pine); color: #fff; box-shadow: 0 6px 16px -8px var(--pine); }
+.sp-go:hover { background: var(--pine2); color: #fff; }
+.sp-info { background: #fff; color: var(--pine); border-color: var(--line); }
+.sp-info:hover { background: #f0f5fb; border-color: var(--pine); }
+
+/* ---- "About this site" modal (instant, from SITE_INDEX) --------------- */
+.site-info .si-sec { padding: 10px 0; border-top: 1px solid var(--line); }
+.site-info .si-sec:first-child { border-top: 0; padding-top: 2px; }
+.si-h { font-size: 11px; font-weight: 800; text-transform: uppercase; letter-spacing: .8px;
+  color: var(--muted); margin-bottom: 5px; }
+.si-row { font-size: 14px; color: var(--ink); }
+.si-bio { color: var(--green); font-weight: 600; margin-top: 2px; }
+.si-coords { font-size: 12px; color: var(--muted); margin-top: 3px; }
+.si-coords .bi { color: var(--terra); }
+.si-code { color: var(--muted); font-weight: 700; }
+.si-stats { display: flex; gap: 10px; margin: 4px 0 8px; }
+.si-stat { flex: 1; background: var(--bg); border-radius: 10px; padding: 9px 8px; text-align: center; }
+.si-stat-n { font-weight: 800; font-size: 18px; color: var(--pine); }
+.si-stat-l { font-size: 11px; color: var(--muted); }
+.si-star i { color: var(--pine); }
+.si-fam { display: flex; align-items: center; gap: 8px; }
+.si-dot { width: 13px; height: 13px; border-radius: 50%; display: inline-block;
+  border: 1.5px solid #fff; box-shadow: 0 0 0 1px var(--line); }
 
 .picker-actions { text-align: center; margin: 14px 0 6px; }
 .picker-tour { text-align: center; margin: 2px 0 4px; }


### PR DESCRIPTION
## What
Tapping a site dot on the landing map used to **immediately load the whole bundle and jump to the main view** — no chance to look before committing, and no real 'site info' (the user's exact complaint: *'you click a site, get a popup to explore… but then it just loads — confusing, and I'm not sure the learn-about-site even works'*).

Now a tap opens a small **anchored choice popup**:
- **Explore this site →** (primary, navy) — the existing full load.
- **About this site** (secondary) — an **instant, fully-populated info card** (Where / When / What's been caught / Ecological family) built from the precomputed `SITE_INDEX` with **zero bundle load**. The modal footer is also a launch point (*Explore this site's data →*).

## Why (5-lens panel: Atlas/Leaflet, Alyssa/UX, Aaron/real-user)
The click was destructive (heavy load + tab switch) with no back-out and no 'learn more.' Matching the interaction to the cost of the action: a heavy load earns a confirm step.

## How
- `observeEvent(input$pickerMap_marker_click)` now does `clearPopups() %>% addPopups()` (built from SITE_INDEX by code → identical in by-site and by-species mode) instead of `load_site_full`.
- New `siteExplore` / `siteInfo` observers; popup buttons fire `Shiny.setInputValue(..., {priority:'event'})`.
- Hover label drops its misleading 'Click to explore →' line → quick name-tag + 'Tap for site options'.
- `clearPopups()` added to the mode-swap and the siteExplore path (no popup floats over the loading overlay; double-taps deduped).
- Stale guided-tour copy updated to describe the new flow.

## Verified
End-to-end with **real headless-Chrome clicks** across 3 sites (SRER, HARV, BARR): popup renders, About modal is fully populated below the header, a no-nickname site (BARR / *Lemmus trimucronatus*) renders cleanly with **no NA holes**, and a real click on **Explore** loads the site. R parses clean.

## Note
Water Chem's map was reviewed and intentionally **left as-is** (secondary map, lightweight non-destructive select, already-honest copy) — only a one-word hover clarification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)