### PR TITLE
Home Range: inline Track-an-individual picker on the trap grid

### DIFF
--- a/rsconnect/shinyapps.io/t-lama/RatTrapHistory.dcf
+++ b/rsconnect/shinyapps.io/t-lama/RatTrapHistory.dcf
@@ -5,6 +5,6 @@ account: t-lama
 server: shinyapps.io
 hostUrl: https://api.shinyapps.io/v1
 appId: 9655857
-bundleId: 12125210
+bundleId: 12126592
 url: https://t-lama.shinyapps.io/RatTrapHistory/
 version: 1

--- a/server.R
+++ b/server.R
@@ -107,6 +107,7 @@ server <- function(input, output, session) {
     ch <- setNames(lb$tagID, sprintf("%s  %s · %s · %d caps",
                                      lb$emoji, lb$short, lb$scientificName, lb$captures))
     updateSelectizeInput(session, "indiv", choices = c("Pick a tagID…" = "", ch), server = TRUE)
+    updateSelectizeInput(session, "indivHR", choices = c("Pick an individual…" = "", ch), server = TRUE)
     nav_select("tabs", "overview")
     session$sendCustomMessage("countUp", list())
     session$sendCustomMessage("loadDone", list())   # hide the loading overlay
@@ -311,12 +312,13 @@ server <- function(input, output, session) {
   })
 
   # ---- selecting an individual -------------------------------------------
-  pick_individual <- function(tag) {
+  pick_individual <- function(tag, navigate = TRUE) {
     if (is.null(tag) || is.na(tag) || tag == "") return()
     rv$tag <- tag
-    if (!identical(input$indiv, tag))
-      updateSelectizeInput(session, "indiv", selected = tag)
-    nav_select("tabs", "dossier")
+    # keep BOTH pickers (sidebar + the inline Home-Range one) in lockstep
+    if (!identical(input$indiv, tag))   updateSelectizeInput(session, "indiv",   selected = tag)
+    if (!identical(input$indivHR, tag)) updateSelectizeInput(session, "indivHR", selected = tag)
+    if (navigate) nav_select("tabs", "dossier")
     row <- rv$lb[rv$lb$tagID == tag, ]
     if (nrow(row) && row$rarity[1] %in% c("Epic", "Legendary")) {
       session$sendCustomMessage("confetti", list(big = row$rarity[1] == "Legendary"))
@@ -326,6 +328,12 @@ server <- function(input, output, session) {
   observeEvent(input$indiv, {
     if (!is.null(input$indiv) && input$indiv != "" && !identical(input$indiv, rv$tag))
       pick_individual(input$indiv)
+  }, ignoreInit = TRUE)
+
+  # inline trap-grid picker: change who's tracked WITHOUT leaving Home Range
+  observeEvent(input$indivHR, {
+    if (!is.null(input$indivHR) && input$indivHR != "" && !identical(input$indivHR, rv$tag))
+      pick_individual(input$indivHR, navigate = FALSE)
   }, ignoreInit = TRUE)
 
   observeEvent(input$leaderboard_rows_selected, {
@@ -349,6 +357,7 @@ server <- function(input, output, session) {
     tag <- lb$tagID[1]
     rv$tag <- tag
     updateSelectizeInput(session, "indiv", selected = tag)
+    updateSelectizeInput(session, "indivHR", selected = tag)
   }
 
   # ---- Overview home-nav buttons (Girth-style quick jumps) ---------------

--- a/ui.R
+++ b/ui.R
@@ -176,8 +176,14 @@ ui <- bslib::page_sidebar(
                  p("The ", tags$b("replay"), " animates its captures in order — press ▶ to watch it move."),
                  p(tags$b("Hotspot blur"), " smooths the grid to show its core area."))),
             p("Where on the plot's trap grid this animal kept turning up. Hit play to replay its captures over time.")),
-          div(class = "hr-toggles",
-            checkboxInput("blurMode", "Hotspot blur", value = FALSE))
+          div(class = "hr-controls",
+            div(class = "hr-indiv",
+              tags$label(class = "hr-indiv-lab", `for` = "indivHR",
+                         tagList(bs_icon("search"), " Tracking")),
+              selectizeInput("indivHR", label = NULL, choices = NULL, width = "260px",
+                             options = list(placeholder = "Pick an individual…"))),
+            div(class = "hr-toggles",
+              checkboxInput("blurMode", "Hotspot blur", value = FALSE)))
         ),
         layout_columns(col_widths = c(6, 6),
           card(full_screen = TRUE, card_head("grid-3x3-gap-fill", "Capture heatmap"),

--- a/www/styles.css
+++ b/www/styles.css
@@ -129,6 +129,12 @@ body {
 .chart-hint { color: var(--muted); font-size: 12px; margin: 0 4px 6px; display: flex; align-items: center; gap: 6px; }
 .chart-hint .bi { color: var(--gold-ink); }
 .map-controls { display: flex; gap: 14px; align-items: flex-end; }
+/* inline "Tracking" individual picker in the Home Range tab head */
+.hr-controls { display: flex; gap: 18px; align-items: flex-end; flex-wrap: wrap; }
+.hr-indiv { display: flex; flex-direction: column; gap: 3px; }
+.hr-indiv-lab { font-size: 12px; font-weight: 700; color: var(--pine); margin: 0; display: flex; align-items: center; gap: 5px; }
+.hr-indiv-lab .bi { color: var(--gold-ink); }
+.hr-indiv .form-group, .hr-indiv .shiny-input-container { margin-bottom: 0; width: 260px; }
 
 /* leaderboard category "chips" */
 .leader-cats .shiny-options-group { display: flex; gap: 6px; flex-wrap: wrap; }


### PR DESCRIPTION
Adds an inline 'Tracking' picker in the Home Range tab head (synced with the sidebar) so it's clear which individual the trap-grid heatmap/replay belong to. Picking from it stays on Home Range instead of jumping to the Dossier. Verified in preview: sync both ways, no unwanted navigation, heatmap renders for the tracked animal.