### PR TITLE
Harden Leaflet maps against blank paint on re-show

### DIFF
--- a/server.R
+++ b/server.R
@@ -428,6 +428,9 @@ server <- function(input, output, session) {
   observeEvent(input$changeSite, {
     rv$data <- NULL; rv$lb <- NULL; rv$lb_view <- NULL; rv$tag <- NULL; rv$label <- NULL; rv$env <- NULL
     shinyjs::hide("mainTabsWrap"); shinyjs::hide("indivPickerWrap"); shinyjs::hide("envPickerWrap"); shinyjs::show("splash")
+    # the picker map was hidden while a site was loaded; nudge it to recompute
+    # size now that it's visible again, so it never paints blank/grey on return
+    session$sendCustomMessage("kickMaps", list())
   })
 
   observeEvent(input$demoBtn, {

--- a/www/app.js
+++ b/www/app.js
@@ -205,5 +205,17 @@ document.addEventListener("DOMContentLoaded", function () {
     Shiny.addCustomMessageHandler("smtLoadStart", function (msg) {
       smtLoadStart(msg && msg.label);
     });
+    // A Leaflet map that initialised inside a hidden tab/container (the Plot-map
+    // tab, or the picker map re-shown after "change site") can paint blank until
+    // it recomputes its size. Dispatching 'resize' makes every Leaflet map
+    // invalidateSize. The server kicks this after re-showing the splash.
+    Shiny.addCustomMessageHandler("kickMaps", function () {
+      setTimeout(function () { try { window.dispatchEvent(new Event("resize")); } catch (e) {} }, 90);
+    });
   }
+});
+
+// Re-fit any Leaflet map the moment its tab becomes visible (hidden-init blank fix).
+document.addEventListener("shown.bs.tab", function () {
+  setTimeout(function () { try { window.dispatchEvent(new Event("resize")); } catch (e) {} }, 60);
 });


### PR DESCRIPTION
Picker map now persists across change-site (hidden→shown); add a resize/invalidateSize kick on tab-show and splash re-show so maps never paint blank/grey on return. Maps verified rendering in all paths; this is robustness for cold-start + hidden-tab cases.