### PR TITLE
Fix Connect Cloud spinner: resync manifest + harden bundle loads

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -1,10 +1,17 @@
 name: Refresh NEON data bundle
 
-# Monthly rebuild of the per-site .rds bundles (data/sites/*.rds mammal data +
-# data/env/*.rds environmental overlays), then redeploy.
+# Monthly rebuild of the per-site MAMMAL .rds bundles (data/sites/*.rds), then
+# redeploy.
 # Runs late on the FIRST SATURDAY NIGHT of each month (~11pm Arizona time) so the
 # brief redeploy lands off-peak. NEON publishes on a lag, so a monthly pull keeps
 # the bundled "database" current.
+#
+# NOTE: the environmental-overlay bundle (data/env/*.rds, the "Compare with
+# environment" layers) is NOT built here. That pull — especially soil water
+# content (DP1.00094.001), a very-high-volume 30-min sensor product — is too
+# heavy/slow for CI (it ran 1h37m and was canceled before deploy). Build it
+# manually when needed:  Rscript scripts/refresh_env_data.R  then commit
+# data/env/. The app ships a demo overlay as a graceful fallback meanwhile.
 #
 # REQUIRES three repo secrets (Settings → Secrets and variables → Actions):
 #   SHINYAPPS_NAME    your shinyapps account name   (e.g. t-lama)
@@ -86,10 +93,7 @@ jobs:
           rm -f data/sites/*.rds
           Rscript scripts/refresh_data.R
 
-      # Deploy right after the MAMMAL bundle — the live app gets fresh data even
-      # if the heavy, optional env-overlay build below runs long or is canceled.
-      # (The env build previously ran 1h37m and was canceled before deploy could
-      # run; deploying first decouples the core refresh from that runaway step.)
+      # Deploy right after the MAMMAL bundle is rebuilt.
       - name: Deploy to shinyapps.io
         env:
           SHINYAPPS_NAME:   ${{ secrets.SHINYAPPS_NAME }}
@@ -98,19 +102,6 @@ jobs:
         run: |
           Rscript -e 'rsconnect::setAccountInfo(Sys.getenv("SHINYAPPS_NAME"), Sys.getenv("SHINYAPPS_TOKEN"), Sys.getenv("SHINYAPPS_SECRET")); source("scripts/deploy.R")'
 
-      # Environmental-overlay bundle (precip / temp / RH / soil moisture /
-      # fruiting) for the "Compare with environment" feature. Heavy + OPTIONAL:
-      # runs AFTER deploy, is non-fatal, AND time-boxed so it can never stall or
-      # block the core mammal refresh + deploy. If it times out, the app simply
-      # keeps using the committed demo overlay until the env build is made lighter.
-      - name: Rebuild the environmental-overlay bundle (full re-pull)
-        if: ${{ github.event.inputs.skip_download != 'true' }}
-        continue-on-error: true
-        timeout-minutes: 50
-        run: |
-          rm -f data/env/*.rds
-          Rscript scripts/refresh_env_data.R
-
       # Land the refreshed bundle on main via a PR (re-uses one branch/PR each
       # run, so they don't pile up). Skips cleanly when nothing changed.
       - name: Open/update data-refresh PR
@@ -118,17 +109,17 @@ jobs:
         with:
           add-paths: |
             data/sites
-            data/env
           branch: auto/data-refresh
           delete-branch: true
           commit-message: "data: monthly NEON refresh"
           title: "data: monthly NEON refresh"
           body: |
-            Automated monthly re-pull of NEON data into the bundles:
-            - small-mammal box trapping (`DP1.10072.001`) → `data/sites/*.rds`
-            - environmental overlays (precip / temp / RH / soil moisture /
-              fruiting) → `data/env/*.rds` for the "Compare with environment" feature.
+            Automated monthly re-pull of NEON small-mammal box-trapping data
+            (`DP1.10072.001`) into `data/sites/*.rds`.
 
             The live app has already been redeployed from this data — merging
             this PR just keeps the committed bundle (and local runs) in sync.
+
+            (Environmental overlays in `data/env/` are built manually via
+            `scripts/refresh_env_data.R`, not in this workflow.)
           labels: automated, data

--- a/global.R
+++ b/global.R
@@ -55,21 +55,32 @@ SITE_DIR  <- "data/sites"
 DEMO_PATH <- "data-sample/jorn_2017_2021.rds"   # fallback if the bundle isn't built
 DEMO_META <- list(site = "JORN", label = "JORN · Jornada Experimental Range")
 
+# Defensive bundle read: a tibble, or NULL when the file is missing OR can't be
+# deserialized (corrupt .rds, or a non-portable serialization the deploy R can't
+# read). A bad bundle must NEVER crash app startup or hang a render — an empty
+# layer with a visible notice beats an infinite loading spinner. (readRDS throws
+# on a bad file, so the bare `readRDS()` calls this replaces could take down the
+# whole session before the UI ever painted.)
+read_bundle <- function(f) {
+  if (!file.exists(f)) return(NULL)
+  out <- tryCatch(
+    tibble::as_tibble(readRDS(f)),
+    error = function(e) {
+      warning(sprintf("read_bundle('%s') failed: %s", f, conditionMessage(e)))
+      NULL
+    })
+  if (is.null(out) || !nrow(out)) NULL else out
+}
+
 # ---- national site index (the picker map) ---------------------------------
 # scripts/build_site_index.R precomputes one row per bundled site with the
 # headline numbers the landing map needs (captures, richness, dominant species
 # + its group color/emoji). Loaded once here so the map is instant on boot.
-SITE_INDEX <- local({
-  f <- "data/site_index.rds"
-  if (file.exists(f)) tibble::as_tibble(readRDS(f)) else NULL
-})
+SITE_INDEX <- read_bundle("data/site_index.rds")
 
 # Per-species national ranges (where each species is caught + per-site abundance)
 # powering the "explore by species" range map on the landing.
-SPECIES_RANGES <- local({
-  f <- "data/species_ranges.rds"
-  if (file.exists(f)) tibble::as_tibble(readRDS(f)) else NULL
-})
+SPECIES_RANGES <- read_bundle("data/species_ranges.rds")
 
 # Species choices for the range picker: grouped by family, labeled with emoji +
 # how widespread, sorted by total individuals (most abundant first).
@@ -88,10 +99,9 @@ species_choices <- function() {
   lapply(split_lab, as.list)
 }
 
-# Read a bundled site's full record, or NULL if not bundled.
+# Read a bundled site's full record, or NULL if not bundled (or unreadable).
 load_site_bundle <- function(site) {
-  f <- file.path(SITE_DIR, paste0(site, ".rds"))
-  if (file.exists(f)) tibble::as_tibble(readRDS(f)) else NULL
+  read_bundle(file.path(SITE_DIR, paste0(site, ".rds")))
 }
 
 # ---- co-located environmental overlays ("compare with environment") --------
@@ -153,8 +163,8 @@ ENV_DEMO <- local({
 load_site_env <- function(site) {
   if (is.null(site) || site == "") return(NULL)
   f <- file.path(ENV_DIR, paste0(site, ".rds"))
-  if (file.exists(f)) {
-    e <- tibble::as_tibble(readRDS(f))
+  e <- read_bundle(f)
+  if (!is.null(e)) {
     attr(e, "source") <- "neon"
     return(e)
   }
@@ -173,8 +183,7 @@ load_site_env <- function(site) {
 load_demo <- function() {
   b <- load_site_bundle("JORN")
   if (!is.null(b)) return(b)
-  if (file.exists(DEMO_PATH)) return(tibble::as_tibble(readRDS(DEMO_PATH)))
-  NULL
+  read_bundle(DEMO_PATH)
 }
 
 # Filter a raw mam table to a [start, end] window. Uses ISO-string comparison

--- a/manifest.json
+++ b/manifest.json
@@ -2966,7 +2966,7 @@
       "checksum": "f0421a06c558a7774fcd33f10fd033ef"
     },
     "data/site_index.rds": {
-      "checksum": "710745f49bdd21507bd1568debb25e03"
+      "checksum": "2e920d321b4d28333ff68b285be43c25"
     },
     "data/sites/ABBY.rds": {
       "checksum": "f27ec86fa8289498ba813de95c8441d0"
@@ -3107,25 +3107,25 @@
       "checksum": "a99514d5510982e2a9f48042efe3e278"
     },
     "data/species_ranges.rds": {
-      "checksum": "2afbf25e5bcd917661e2b5538693aec2"
+      "checksum": "47dbc051e5ea51a5fdb7b618e7acd8c4"
     },
     "global.R": {
-      "checksum": "8fbb2a4d6c68c8928f04e73edbc2754a"
+      "checksum": "fd847a3bf92d2e7f868b4156c104e7df"
     },
     "R/helpers.R": {
-      "checksum": "53e64bacc1746644b0aed985325898ad"
+      "checksum": "8aac5d57bb94c2ec52b5b797213ed4ea"
     },
     "R/site_metadata.R": {
       "checksum": "dd998c7eb8763e4ae1f33c060ed8364a"
     },
     "server.R": {
-      "checksum": "f313b8b895164c9ef0218d098cbfead7"
+      "checksum": "d1121e39514123648e71f8dd6b09b440"
     },
     "ui.R": {
-      "checksum": "821a97ec900d3398cfdabda9084246fc"
+      "checksum": "a5d5ee3d38690ac7d9de51380718294d"
     },
     "www/app.js": {
-      "checksum": "cc3b941a6b16405d7fe6876dc549deab"
+      "checksum": "d9e924548bfa08d0b5c96efc6c1700e5"
     },
     "www/confirm.js": {
       "checksum": "c05030299121b6bb32e2794f0decb120"
@@ -3143,7 +3143,7 @@
       "checksum": "03caa0fdc9353ecf3495715d7e5f11f5"
     },
     "www/styles.css": {
-      "checksum": "a79f4b008c2c2029607698336fefb123"
+      "checksum": "880690977533295ee9b9bbfffecad9e4"
     },
     "data-sample/env_demo.csv": {
       "checksum": "7e335a0b4e978711168ca5aa677b3778"

--- a/server.R
+++ b/server.R
@@ -662,7 +662,13 @@ server <- function(input, output, session) {
 
   # base map drawn once (tiles + view + initial by-site markers)
   output$pickerMap <- renderLeaflet({
-    req(SITE_INDEX, nrow(SITE_INDEX) > 0)
+    # Show a clear notice (not an endless spinner) if the site index didn't load.
+    # `req()` here would silently halt and spin forever; `validate()` surfaces the
+    # cause in-place so a missing/unreadable data/site_index.rds is diagnosable.
+    validate(need(
+      !is.null(SITE_INDEX) && nrow(SITE_INDEX) > 0,
+      "The national site map couldn't load its data (data/site_index.rds is missing or unreadable in this deployment). The rest of the app still works — pick a site, or try the demo."
+    ))
     leaflet(options = leafletOptions(minZoom = 2, worldCopyJump = TRUE)) %>%
       addProviderTiles("CartoDB.Positron", options = providerTileOptions(noWrap = TRUE)) %>%
       setView(lng = -96, lat = 41, zoom = 4) %>%


### PR DESCRIPTION
## Why the live app spins forever

The Posit Connect Cloud deployment (`*.share.connect.posit.cloud`) is **git-backed** and reads `manifest.json` as the source of truth on every push to `main`. As PRs #18→#26 merged, **8 files drifted from their recorded manifest checksums** without the manifest ever being regenerated:

```
data/site_index.rds      ← powers the landing "picker map" (the thing spinning)
data/species_ranges.rds
global.R  server.R  ui.R  R/helpers.R  www/app.js  www/styles.css
```

A stale/mismatched `site_index.rds` means `SITE_INDEX` loads empty, and the picker map's `req(SITE_INDEX, nrow > 0)` then halts silently → the `rat1.gif` loader spins indefinitely (the reported symptom).

### Ruled out first
- **Not the bundle data** — every committed `.rds` is clean (no arrow/ALTREP), populated, and unchanged since the manifest commit.
- **Not a missing/bloated package** — the 91-package manifest is the exact dependency closure of the app's used packages (`leaflet` genuinely Imports `raster`/`sf`→`terra`/`s2`/etc.). **Nothing is removable**; an earlier "slim the manifest" idea would have *broken* the build.

## Changes

**1. Resync `manifest.json` checksums** to the committed bytes (checksum-only diff; package list untouched). Verified: all 62 files now consistent, JSON valid, closure intact.

**2. Harden startup** so this class of failure can never again present as a silent infinite spinner:
- All bundle reads go through a defensive `read_bundle()` (`tryCatch` → `NULL` instead of crashing on a corrupt/non-portable `.rds`).
- The picker map's silent `req()` becomes `validate(need(...))`, surfacing a clear in-place message if the site index can't load.

**3. Drop the heavy environmental-overlay pull from CI.** The env build — soil water content (`DP1.00094.001`), a very-high-volume 30-min sensor product across ~12yr × ~47 sites — ran **1h37m and the runner was canceled mid soil-sensor stacking**, which is why the earlier refresh never deployed. The monthly workflow now does only the lean mammal refresh + deploy. The overlay feature and its demo fallback stay; env bundles are built manually via `scripts/refresh_env_data.R` when wanted.

## Testing notes
Validated statically here (no R runtime / Connect deploy available from this environment): JSON parses, all manifest checksums match the working tree, dependency closure unchanged, workflow YAML valid, diffs reviewed. **The live test is the Connect Cloud rebuild that fires when this merges to `main`** — after merge, the picker map should paint; if anything still fails to load, it now shows a readable message instead of spinning.

https://claude.ai/code/session_01JG2s58hUdf6SJMwL2SpFac