### PR TITLE
UI: space splash buttons + fix chonk-gauge mobile cutoff

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3257,10 +3257,10 @@
       "checksum": "dd998c7eb8763e4ae1f33c060ed8364a"
     },
     "server.R": {
-      "checksum": "7a5571ba8b94d57e33d543fcfe468394"
+      "checksum": "ade3364daa861ae0d1c878fbf4a63296"
     },
     "ui.R": {
-      "checksum": "9cf01a99d2515c13e9193c32e936fbcf"
+      "checksum": "5d63507a0fb1d9dcbdd8ce0c8ee7848a"
     },
     "www/app.js": {
       "checksum": "d9e924548bfa08d0b5c96efc6c1700e5"
@@ -3281,7 +3281,7 @@
       "checksum": "03caa0fdc9353ecf3495715d7e5f11f5"
     },
     "www/styles.css": {
-      "checksum": "880690977533295ee9b9bbfffecad9e4"
+      "checksum": "7ee0613cad480f7ceea10e6bd16b2a8c"
     }
   },
   "users": null

--- a/server.R
+++ b/server.R
@@ -1059,13 +1059,13 @@ server <- function(input, output, session) {
       return(note_plot("Not enough adult weights<br>for this species to rank", "\U0001F9CA"))
     plot_ly(type = "indicator", mode = "gauge+number+delta",
       value = pct,
-      number = list(suffix = "", font = list(color = "#1f2a30", size = 46)),
+      number = list(suffix = "", font = list(color = "#1f2a30", size = 40)),
       delta = list(reference = 50, suffix = " vs typical",
         increasing = list(color = "#1a7f37"), decreasing = list(color = "#2f7fb5"),
         font = list(size = 13)),
       title = list(text = sprintf("<b>%s</b><br><span style='font-size:12px;color:#6b7a85'>adult weight percentile vs %s</span>",
                                   row$chonk_tier[1], row$scientificName[1]),
-                   font = list(color = "#1f2a30", size = 18)),
+                   font = list(color = "#1f2a30", size = 16)),
       gauge = list(
         axis = list(range = list(0, 100), tickcolor = "#6b7a85", tickfont = list(color = "#6b7a85")),
         bar = list(color = "#0C234B", thickness = 0.28),
@@ -1079,7 +1079,7 @@ server <- function(input, output, session) {
         threshold = list(line = list(color = "#AB0520", width = 3), thickness = 0.8, value = 50))
     ) %>% plotly::layout(paper_bgcolor = "rgba(0,0,0,0)", plot_bgcolor = "rgba(0,0,0,0)",
                          font = list(color = "#344049", family = "Rubik"),
-                         margin = list(t = 70, b = 10, l = 30, r = 30)) %>%
+                         margin = list(t = 48, b = 26, l = 30, r = 30)) %>%
       plotly::config(displayModeBar = FALSE)
   })
 

--- a/ui.R
+++ b/ui.R
@@ -223,7 +223,7 @@ ui <- bslib::page_sidebar(
           actionButton("demoBtn2", tagList(bs_icon("stars"), " Or jump straight into the Jornada demo"),
                        class = "btn-primary btn-lg", onclick = "smtLoadStart('Jornada — demo dataset')"),
           actionButton("compareBtn", tagList(bs_icon("bar-chart-steps"), " Compare two sites"),
-                       class = "btn-outline-dark btn-lg ms-2")),
+                       class = "btn-outline-dark btn-lg")),
         div(class = "picker-tour",
           tags$a(href = "#", onclick = "smtTour();return false;",
                  bs_icon("signpost-2"), " Take a 30-second tour")),

--- a/www/styles.css
+++ b/www/styles.css
@@ -367,7 +367,8 @@ table.dataTable td, table.dataTable th { border-color: #eef1ec !important; color
 .si-dot { width: 13px; height: 13px; border-radius: 50%; display: inline-block;
   border: 1.5px solid #fff; box-shadow: 0 0 0 1px var(--line); }
 
-.picker-actions { text-align: center; margin: 14px 0 6px; }
+.picker-actions { display: flex; flex-wrap: wrap; justify-content: center;
+  gap: 12px; margin: 16px 0 6px; }
 .picker-tour { text-align: center; margin: 2px 0 4px; }
 .picker-tour a { font-size: 12.5px; font-weight: 600; color: var(--sky); text-decoration: none; }
 .picker-tour a:hover { color: var(--pine); text-decoration: underline; }


### PR DESCRIPTION
Two small mobile-UI fixes (reported from the live app on a phone):

- **Splash demo/compare buttons** were crowding each other. `.picker-actions` is now a flex row with `gap:12px` that wraps to a clean vertical gap on narrow screens; dropped the redundant `ms-2`.
- **Chonk Index gauge was clipping at the bottom on mobile.** Trimmed the number (46→40) and title (18→16) fonts and eased the top margin (70→48, bottom 10→26) so the gauge + 0/100 labels + delta fit; kept card height at 360 to align with the measurements card beside it. Verified at 375px via DOM geometry — nothing draws past the container bottom.

`manifest.json` checksums refreshed (LF/git-blob) for `ui.R`, `server.R`, `www/styles.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)