### PR TITLE
ui: restyle correlation narrative with centered chip-badge layout

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3260,7 +3260,7 @@
       "checksum": "dd998c7eb8763e4ae1f33c060ed8364a"
     },
     "server.R": {
-      "checksum": "3466e25c65c3982f73c13b0cb27fb911"
+      "checksum": "9d0b2bbf6b6200379611390b40f9e641"
     },
     "ui.R": {
       "checksum": "9bd4544c974de30da05d62e8f0e6eedc"
@@ -3284,7 +3284,7 @@
       "checksum": "03caa0fdc9353ecf3495715d7e5f11f5"
     },
     "www/styles.css": {
-      "checksum": "4c813dfb32c3b7d22aa43bea51959ea8"
+      "checksum": "c2b951f021118a6e8bcafdd8dc21cc7b"
     }
   },
   "users": null

--- a/server.R
+++ b/server.R
@@ -115,14 +115,33 @@ server <- function(input, output, session) {
     strength <- abs(sc$r)
     word <- if (strength >= 0.6) "a strong" else if (strength >= 0.35) "a moderate"
             else if (strength >= 0.2) "a weak" else "little"
-    dir <- if (sc$r >= 0) "more" else "fewer"
+    dir  <- if (sc$r >= 0) "more" else "fewer"
     lagtxt <- if (sc$lag == 0) "the same month" else sprintf("%d month%s earlier",
                 sc$lag, if (sc$lag == 1) "" else "s")
-    tone <- if (strength >= 0.35) "env-corr-strong" else "env-corr-mild"
-    div(class = paste("env-corr", tone), bs_icon("graph-up-arrow"),
-      HTML(sprintf(" Across this window, catch-per-effort shows <b>%s</b> relationship with <b>%s</b> (deseasonalized Pearson r = <b>%+.2f</b>, n = %d months) — strongest when %s is read <b>%s</b>. Higher %s tracks <b>%s</b> animals caught.%s",
-        word, tolower(sc$label), sc$r, sc$n, tolower(sc$label), lagtxt, tolower(sc$label), dir,
-        if (es$demo) " <i>(demo overlay — illustrative)</i>" else "")))
+    tone  <- if (strength >= 0.35) "env-corr-strong" else "env-corr-mild"
+    s_cls <- if (strength >= 0.6) "chip-sig" else if (strength >= 0.35) "chip-mod" else "chip-weak"
+    d_cls <- if (sc$r >= 0) "chip-pos" else "chip-neg"
+    div(class = paste("env-corr", tone),
+      div(class = "corr-head",
+        bs_icon("graph-up-arrow"), " catch-per-effort × ",
+        tags$span(class = "corr-chip chip-driver", tolower(sc$label))
+      ),
+      div(class = "corr-stats",
+        tags$span(class = paste("corr-chip", s_cls), word),
+        tags$span(class = "corr-dot", "·"),
+        tags$span(class = "corr-chip chip-r", HTML(sprintf("r = %+.2f", sc$r))),
+        tags$span(class = "corr-dot", "·"),
+        tags$span(class = "corr-chip chip-n", sprintf("n = %d months", sc$n))
+      ),
+      div(class = "corr-foot",
+        "Strongest when read ",
+        tags$span(class = "corr-chip chip-lag", lagtxt),
+        HTML(" — higher = "),
+        tags$span(class = paste("corr-chip", d_cls), dir),
+        " animals caught",
+        if (es$demo) tags$i(class = "corr-demo-note", " (demo overlay)") else NULL
+      )
+    )
   })
 
   # Response scatter: monthly catch-per-effort vs the (lagged) driver, with fit.

--- a/www/styles.css
+++ b/www/styles.css
@@ -105,13 +105,34 @@ body {
 .pop-caveat .bi { color: var(--gold, #c9a300); }
 
 /* population<->environment correlation readout (Population tab) */
-.env-corr { display: flex; gap: 9px; align-items: flex-start; border-radius: 10px;
-  padding: 11px 14px; margin: 0 0 14px; font-size: 13.5px; line-height: 1.5; }
-.env-corr .bi { margin-top: 2px; flex: none; font-size: 17px; }
+@keyframes corrFadeIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
+.env-corr { text-align: center; border-radius: 12px; padding: 14px 18px 13px;
+  margin: 0 0 14px; animation: corrFadeIn .3s ease; }
 .env-corr-strong { background: #eef6f0; border: 1px solid #cfe6d6; color: #21503a; }
-.env-corr-strong .bi { color: var(--pine, #1a7f37); }
+.env-corr-strong .corr-head .bi { color: var(--pine, #1a7f37); }
 .env-corr-mild { background: #f3f6fb; border: 1px solid var(--line); color: #3a4654; }
-.env-corr-mild .bi { color: var(--muted); }
+.env-corr-mild .corr-head .bi { color: var(--muted); }
+
+.corr-head  { font-size: 13px; font-weight: 700; letter-spacing: .2px; margin-bottom: 9px; }
+.corr-head .bi { font-size: 15px; vertical-align: middle; margin-right: 2px; }
+.corr-stats { display: flex; justify-content: center; align-items: center;
+  flex-wrap: wrap; gap: 5px; margin-bottom: 9px; }
+.corr-foot  { font-size: 12.5px; line-height: 1.8; }
+.corr-dot   { color: var(--muted); opacity: .55; padding: 0 1px; }
+.corr-demo-note { font-size: 11px; opacity: .6; margin-left: 3px; }
+
+.corr-chip { display: inline-flex; align-items: center; border-radius: 5px;
+  padding: 1px 8px 2px; font-size: 12.5px; font-weight: 700; white-space: nowrap;
+  line-height: 1.65; letter-spacing: .1px; }
+.chip-driver { background: rgba(0,0,0,.09); }
+.chip-sig    { background: #c3e6cb; color: #155724; }
+.chip-mod    { background: #ffeeba; color: #7d5a00; }
+.chip-weak   { background: #dee2e6; color: #495057; }
+.chip-r      { background: rgba(0,0,0,.08); font-family: monospace; font-size: 12px; }
+.chip-n      { background: rgba(0,0,0,.05); font-weight: 600; }
+.chip-lag    { background: #e0d6f5; color: #5a3f8a; }
+.chip-pos    { background: #c3e6cb; color: #155724; }
+.chip-neg    { background: #f5c6cb; color: #721c24; }
 
 .or-divider { display: flex; align-items: center; text-align: center; color: var(--muted); margin: 12px 0 8px; font-size: 11px; text-transform: uppercase; letter-spacing: 2px; }
 .or-divider::before, .or-divider::after { content: ""; flex: 1; height: 1px; background: var(--line); margin: 0 10px; }


### PR DESCRIPTION
## Summary
- Replace the flat bold-sentence `envCorrNote` block with a 3-row centered insight card
- Each dynamic token (driver, strength word, r value, n, lag, direction) wrapped in a semantic color chip/badge
- Amber chip for moderate correlation, green for strong/positive, red for inverse, purple for lag, monospace for r value
- Subtle `corrFadeIn` keyframe animation on each re-render so users visually notice the block updating on driver or site change

## Chip color map
| Token | Class | Color |
|-------|-------|-------|
| Driver name | `chip-driver` | Translucent dark |
| Strong r | `chip-sig` | Green |
| Moderate r | `chip-mod` | Amber |
| Weak/little r | `chip-weak` | Gray |
| r value | `chip-r` | Monospace, subtle |
| n months | `chip-n` | Subtle |
| Lag | `chip-lag` | Purple |
| More animals | `chip-pos` | Green |
| Fewer animals | `chip-neg` | Red |

## Test plan
- [ ] Load Jornada demo → Population tab → select any env overlay → confirm 3-row centered layout renders
- [ ] Switch drivers (air temp / precip / phenology) — block fades in each time, chips update correctly
- [ ] Negative r sites show red "fewer" chip; positive r shows green "more"
- [ ] Strong correlation (|r| ≥ 0.6) shows green strength chip; moderate shows amber; weak shows gray

🤖 Generated with [Claude Code](https://claude.com/claude-code)