### PR TITLE
ui: redesign env-correlation narrative + render it on initial load

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3260,10 +3260,10 @@
       "checksum": "dd998c7eb8763e4ae1f33c060ed8364a"
     },
     "server.R": {
-      "checksum": "9d0b2bbf6b6200379611390b40f9e641"
+      "checksum": "918c3b746482704f5b6f352558bcaad7"
     },
     "ui.R": {
-      "checksum": "9bd4544c974de30da05d62e8f0e6eedc"
+      "checksum": "fd2aa5a93221ae3503871544f6c716e7"
     },
     "www/app.js": {
       "checksum": "cf9fef6bdba15afc099cfb388b811ea9"
@@ -3284,7 +3284,7 @@
       "checksum": "03caa0fdc9353ecf3495715d7e5f11f5"
     },
     "www/styles.css": {
-      "checksum": "c2b951f021118a6e8bcafdd8dc21cc7b"
+      "checksum": "29a011a33ca8ffaa894b20c1a06de0a0"
     }
   },
   "users": null

--- a/server.R
+++ b/server.R
@@ -109,39 +109,52 @@ server <- function(input, output, session) {
   # this site's monthly catch-per-effort and the selected (lagged) driver.
   output$envCorrNote <- renderUI({
     es <- env_sel(); d <- rv$data
-    if (is.null(es) || is.null(d)) return(NULL)
+    if (is.null(d)) return(NULL)
+    # On initial load no layer is picked (env_sel() is NULL), but the ranking
+    # card + auto-overlay below already default to the BEST-correlated driver.
+    # Mirror that here so the narrative renders immediately and describes the
+    # same driver — instead of staying blank until the user taps a bar.
+    if (is.null(es)) {
+      if (is.null(rv$env)) return(NULL)
+      ca <- env_corr_all(d, rv$env)
+      if (is.null(ca) || !nrow(ca)) return(NULL)
+      w  <- ca[1, ]
+      es <- list(layer = w$layer, lag = as.integer(w$lag), env = rv$env,
+                 demo = identical(attr(rv$env, "source"), "demo"))
+    }
     sc <- env_corr_scan(d, es$env, es$layer)
     if (is.null(sc)) return(NULL)
+    # The redesign reads as one designed "answer" to the card below it:
+    #   eyebrow · hero sentence + hero r-value · supporting metadata.
+    # Strength drives the left rail + the bold verdict word; SIGN drives the
+    # r-value color + arrow glyph + the "more/fewer" word — kept on separate
+    # visual channels so a strong-but-inverse link never reads as "weak".
     strength <- abs(sc$r)
-    word <- if (strength >= 0.6) "a strong" else if (strength >= 0.35) "a moderate"
-            else if (strength >= 0.2) "a weak" else "little"
-    dir  <- if (sc$r >= 0) "more" else "fewer"
-    lagtxt <- if (sc$lag == 0) "the same month" else sprintf("%d month%s earlier",
-                sc$lag, if (sc$lag == 1) "" else "s")
-    tone  <- if (strength >= 0.35) "env-corr-strong" else "env-corr-mild"
-    s_cls <- if (strength >= 0.6) "chip-sig" else if (strength >= 0.35) "chip-mod" else "chip-weak"
-    d_cls <- if (sc$r >= 0) "chip-pos" else "chip-neg"
-    div(class = paste("env-corr", tone),
-      div(class = "corr-head",
-        bs_icon("graph-up-arrow"), " catch-per-effort × ",
-        tags$span(class = "corr-chip chip-driver", tolower(sc$label))
-      ),
-      div(class = "corr-stats",
-        tags$span(class = paste("corr-chip", s_cls), word),
-        tags$span(class = "corr-dot", "·"),
-        tags$span(class = "corr-chip chip-r", HTML(sprintf("r = %+.2f", sc$r))),
-        tags$span(class = "corr-dot", "·"),
-        tags$span(class = "corr-chip chip-n", sprintf("n = %d months", sc$n))
-      ),
-      div(class = "corr-foot",
-        "Strongest when read ",
-        tags$span(class = "corr-chip chip-lag", lagtxt),
-        HTML(" — higher = "),
-        tags$span(class = paste("corr-chip", d_cls), dir),
-        " animals caught",
-        if (es$demo) tags$i(class = "corr-demo-note", " (demo overlay)") else NULL
-      )
-    )
+    pos    <- sc$r >= 0
+    dir    <- if (pos) "more" else "fewer"
+    rail   <- if (strength >= 0.6) "rail-strong" else if (strength >= 0.35) "rail-mod" else "rail-weak"
+    slabel <- if (strength >= 0.6) "Strong" else if (strength >= 0.35) "Moderate"
+              else if (strength >= 0.2) "Weak" else "Negligible"
+    glyph  <- if (pos) "arrow-up-right" else "arrow-down-right"
+    div(class = paste("ec", rail),
+      div(class = "ec-eyebrow",
+        bs_icon("graph-up-arrow"), tags$span("environmental tracking"),
+        if (es$demo) tags$span(class = "ec-demo", "demo overlay") else NULL),
+      div(class = "ec-hero",
+        div(class = "ec-hero-text",
+          tags$span(class = "ec-strength", slabel), " link with ",
+          tags$span(class = "ec-driver", tolower(sc$label))),
+        div(class = paste("ec-rvalue", if (pos) "ec-sgn-pos" else "ec-sgn-neg"),
+          bs_icon(glyph), HTML(sprintf("r&nbsp;%+.2f", sc$r)))),
+      div(class = "ec-foot",
+        tags$span(class = "ec-meta", bs_icon("clock-history"),
+          if (sc$lag == 0) "same-month signal"
+          else HTML(sprintf("<b>%d-mo</b> lead", sc$lag))),
+        tags$span(class = "ec-meta-dot"),
+        tags$span(class = "ec-meta", bs_icon("calendar3"),
+          HTML(sprintf("<b>%d</b> months matched", sc$n))),
+        tags$span(class = paste("ec-meta ec-dir", if (pos) "ec-sgn-pos" else "ec-sgn-neg"),
+          HTML(sprintf("higher \U2192 <b>%s</b> animals", dir)))))
   })
 
   # Response scatter: monthly catch-per-effort vs the (lagged) driver, with fit.

--- a/ui.R
+++ b/ui.R
@@ -374,7 +374,6 @@ ui <- bslib::page_sidebar(
             h4("Defensible population signals"),
             p("Minimum Number Known Alive (MNKA) and catch-per-unit-effort are honest abundance indices; the accumulation curve shows whether trapping ran long enough to find every species."))
         ),
-        uiOutput("envCorrNote"),
         conditionalPanel("output.hasEnv == true",
           card(full_screen = TRUE,
             card_head("bar-chart-steps", "Which environmental driver does this population track best?",
@@ -383,6 +382,7 @@ ui <- bslib::page_sidebar(
                 p("Bars show that best correlation (sign = direction); the label is the lag at which it peaks. The longest bar is the signal this population follows most closely — the others are candidate co-drivers."),
                 p(class = "pop-caveat", bs_icon("exclamation-triangle"),
                   " A longer bar isn't proof of cause: drivers correlate with each other, and scanning many lags can flag a strong match by chance. Treat this as a ranking of leads to investigate."))),
+            uiOutput("envCorrNote"),
             spin(plotlyOutput("envDriverRank", height = "300px")))),
         card(full_screen = TRUE,
           card_head("incognito", "Detection-corrected abundance",

--- a/www/styles.css
+++ b/www/styles.css
@@ -104,35 +104,95 @@ body {
   border-radius: 7px; padding: 6px 8px; margin: 6px 0 0; line-height: 1.4; }
 .pop-caveat .bi { color: var(--gold, #c9a300); }
 
-/* population<->environment correlation readout (Population tab) */
-@keyframes corrFadeIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
-.env-corr { text-align: center; border-radius: 12px; padding: 14px 18px 13px;
-  margin: 0 0 14px; animation: corrFadeIn .3s ease; }
-.env-corr-strong { background: #eef6f0; border: 1px solid #cfe6d6; color: #21503a; }
-.env-corr-strong .corr-head .bi { color: var(--pine, #1a7f37); }
-.env-corr-mild { background: #f3f6fb; border: 1px solid var(--line); color: #3a4654; }
-.env-corr-mild .corr-head .bi { color: var(--muted); }
+/* =========================================================================
+   ENV-CORRELATION "answer" banner — sits at the top of the driver-ranking
+   card and answers its question (Q in the navy header → A here → bars below).
+   STRENGTH drives the left rail + verdict-word color; SIGN drives the
+   r-value color + arrow glyph + the more/fewer word — kept on separate
+   visual channels so a strong-but-inverse link never reads as "weak".
+   ========================================================================= */
+@keyframes ecReveal { from { opacity: 0; transform: translateY(-3px); } to { opacity: 1; transform: none; } }
 
-.corr-head  { font-size: 13px; font-weight: 700; letter-spacing: .2px; margin-bottom: 9px; }
-.corr-head .bi { font-size: 15px; vertical-align: middle; margin-right: 2px; }
-.corr-stats { display: flex; justify-content: center; align-items: center;
-  flex-wrap: wrap; gap: 5px; margin-bottom: 9px; }
-.corr-foot  { font-size: 12.5px; line-height: 1.8; }
-.corr-dot   { color: var(--muted); opacity: .55; padding: 0 1px; }
-.corr-demo-note { font-size: 11px; opacity: .6; margin-left: 3px; }
+.ec {
+  position: relative;
+  margin: -8px 0 16px;                          /* pull up to sit under the navy header */
+  padding: 12px 16px 11px 18px;
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--ec-rail, var(--muted));
+  border-radius: 9px;
+  background: linear-gradient(180deg, #f4f8fd 0%, var(--paper) 100%);
+  box-shadow: 0 1px 2px rgba(12, 35, 75, .05);
+  animation: ecReveal .3s ease;
+}
+.ec.rail-strong { --ec-rail: #1a7f37; }          /* green (no green CSS token in this theme) */
+.ec.rail-mod    { --ec-rail: #c9a300; }          /* amber */
+.ec.rail-weak   { --ec-rail: var(--muted); }
 
-.corr-chip { display: inline-flex; align-items: center; border-radius: 5px;
-  padding: 1px 8px 2px; font-size: 12.5px; font-weight: 700; white-space: nowrap;
-  line-height: 1.65; letter-spacing: .1px; }
-.chip-driver { background: rgba(0,0,0,.09); }
-.chip-sig    { background: #c3e6cb; color: #155724; }
-.chip-mod    { background: #ffeeba; color: #7d5a00; }
-.chip-weak   { background: #dee2e6; color: #495057; }
-.chip-r      { background: rgba(0,0,0,.08); font-family: monospace; font-size: 12px; }
-.chip-n      { background: rgba(0,0,0,.05); font-weight: 600; }
-.chip-lag    { background: #e0d6f5; color: #5a3f8a; }
-.chip-pos    { background: #c3e6cb; color: #155724; }
-.chip-neg    { background: #f5c6cb; color: #721c24; }
+.ec-eyebrow {
+  display: flex; align-items: center; gap: 6px; margin-bottom: 7px;
+  font-size: 10px; font-weight: 800; letter-spacing: 1.2px; text-transform: uppercase;
+  color: var(--muted);
+}
+.ec-eyebrow .bi { font-size: 12px; color: var(--ec-rail); }
+.ec-demo {
+  margin-left: auto; font-size: 9px; font-weight: 700; letter-spacing: .5px;
+  text-transform: uppercase; color: var(--gold-ink);
+  background: rgba(201, 163, 0, .12); border: 1px solid rgba(201, 163, 0, .32);
+  border-radius: 20px; padding: 1px 8px;
+}
+
+.ec-hero { display: flex; align-items: center; justify-content: space-between; gap: 14px; }
+.ec-hero-text { flex: 1 1 auto; min-width: 0; font-size: 15px; line-height: 1.35;
+  font-weight: 500; color: var(--ink); }
+.ec-strength { font-weight: 800; color: var(--ec-rail); }
+.ec-driver { font-weight: 800; color: var(--ink);
+  border-bottom: 2px solid var(--ec-rail); padding-bottom: 1px; }
+
+.ec-rvalue {
+  flex: 0 0 auto; display: inline-flex; align-items: center; gap: 3px; white-space: nowrap;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 25px; font-weight: 700; line-height: 1; letter-spacing: -.5px;
+  font-variant-numeric: tabular-nums;
+}
+.ec-rvalue .bi { font-size: 18px; }
+.ec-rvalue.ec-sgn-pos { color: #1a7f37; }
+.ec-rvalue.ec-sgn-neg { color: var(--terra, #AB0520); }
+
+.ec-foot {
+  display: flex; align-items: center; flex-wrap: wrap; gap: 4px 9px;
+  margin-top: 10px; padding-top: 8px; border-top: 1px solid var(--line);
+  font-size: 11.5px; color: var(--muted);
+}
+.ec-meta { display: inline-flex; align-items: center; gap: 4px; line-height: 1.4; }
+.ec-meta .bi { font-size: 12px; opacity: .85; }
+.ec-meta b { color: var(--ink); font-weight: 800; }
+.ec-meta-dot { width: 3px; height: 3px; border-radius: 50%; background: currentColor; opacity: .4; }
+.ec-dir { margin-left: auto; }                   /* push "higher -> more/fewer" to the right edge */
+.ec-dir.ec-sgn-pos b { color: #1a7f37; }
+.ec-dir.ec-sgn-neg b { color: var(--terra, #AB0520); }
+
+/* ---- dark mode (mirrors the app-wide [data-bs-theme="dark"] pattern) ---- */
+[data-bs-theme="dark"] .ec {
+  background: linear-gradient(180deg, #1b2942 0%, var(--paper) 100%);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, .3);
+}
+[data-bs-theme="dark"] .ec.rail-strong { --ec-rail: #5fcf86; }   /* raw greens read dim on navy */
+[data-bs-theme="dark"] .ec.rail-mod    { --ec-rail: var(--gold-ink); }
+[data-bs-theme="dark"] .ec-rvalue.ec-sgn-pos,
+[data-bs-theme="dark"] .ec-dir.ec-sgn-pos b { color: #5fcf86; }
+[data-bs-theme="dark"] .ec-rvalue.ec-sgn-neg,
+[data-bs-theme="dark"] .ec-dir.ec-sgn-neg b { color: #ff7a8a; }  /* cardinal too dark on navy */
+[data-bs-theme="dark"] .ec-demo {
+  color: var(--gold-ink); background: rgba(232, 197, 82, .12); border-color: rgba(232, 197, 82, .32);
+}
+
+/* ---- narrow / mobile (~380px): stack the hero, let the r-value own its row ---- */
+@media (max-width: 560px) {
+  .ec-hero { flex-direction: column; align-items: flex-start; gap: 5px; }
+  .ec-hero-text { font-size: 14px; }
+  .ec-rvalue { font-size: 28px; }
+  .ec-dir { margin-left: 0; flex-basis: 100%; }
+}
 
 .or-divider { display: flex; align-items: center; text-align: center; color: var(--muted); margin: 12px 0 8px; font-size: 11px; text-transform: uppercase; letter-spacing: 2px; }
 .or-divider::before, .or-divider::after { content: ""; flex: 1; height: 1px; background: var(--line); margin: 0 10px; }


### PR DESCRIPTION
## What & why
The population↔environment correlation readout on the **Population** tab had two problems the user flagged:

1. **It didn't render on initial load.** The narrative read `env_sel()` directly, which is `NULL` until you pick or tap a driver — so on first view of the tab it was blank, only appearing after you clicked a ranking bar.
2. **It looked "kind of ugly"** — a scattered cloud of equally-weighted colored pills with no focal point, floating in a pale-green box disconnected from the card it answers.

## Fixes
**Render-on-load:** the narrative now falls back to the **best-correlated driver** (the same default the ranking bars + auto-overlay below already use via `env_corr_all`), so it appears immediately and describes the same driver. Still updates live when you tap a bar or change the sidebar picker.

**Redesign** (direction from the Alyssa UI agent): the pill-cloud becomes a designed **"answer" banner folded into the top of the driver-rank card**, so the navy header's *question*, this *answer*, and the bars (*evidence*) read as one unit:
- **Eyebrow** → **hero sentence** ("Strong link with green-up (leaf-out)") + **hero monospace r-value** → **quiet metadata footer** (`N-mo lead · N months matched · higher → more/fewer animals`)
- **Strength and sign on separate visual channels:** strength drives the colored left rail + verdict word (green / amber / gray); sign drives the r-value color + arrow glyph + more/fewer word (green / red). A strong-but-inverse link can no longer be misread as weak — addresses earlier feedback.
- Mode-aware (light + dark, with brighter green/red/gold on dark since raw brand tones read dim on navy) and stacks on narrow screens.

## Verification (headless preview, JORN demo)
DOM + computed-style checks (screenshot capture is wedged in this headless session, so verified via reads):
- ✅ Renders on **initial Population load with no driver click** (`envLayer="none"` → auto-best = air temp, r −0.50, 9-mo lead, n=35)
- ✅ Updates live on driver switch (green-up → r −0.44, 2-mo lead)
- ✅ Folded inside the driver card; **5px** below the navy header
- ✅ Light: amber rail/word for moderate, terra red `#AB0520` r-value for negative sign; strong+positive simulated → green `#1a7f37` rail/word/r-value
- ✅ Dark: banner `#1b2942`, gold-ink rail, green `#5fcf86` / red `#ff7a8a` signs
- ✅ Mobile breakpoint stacks the hero (r-value 28px on its own row)
- ✅ No dangling references to old `.env-corr`/`.corr-*`/`.chip-*` classes

## Test plan
- [ ] Open Population tab on a fresh site load → narrative shows immediately (no click needed)
- [ ] Tap ranking bars / change sidebar driver → banner fades and updates
- [ ] A positive-strong site (e.g. Lower Teakettle green-up) shows green; a negative site shows red
- [ ] Toggle dark mode → colors switch to the bright variants
- [ ] Narrow the window → hero stacks cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)