### PR TITLE
feat: plot-map recapture-connectivity (movement) layer

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -467,6 +467,71 @@ blur_grid <- function(z) {
 }
 
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Between-plot recapture connectivity — the "movement" the dot map throws away.
+# For each individual caught at >=2 distinct plots, link its SUCCESSIVE distinct
+# capture plots (consecutive same-plot recaptures collapsed), aggregate across
+# animals so a plot-pair's weight = number of individuals that made that move.
+# This is mark-recapture, NOT telemetry: the line means "this animal was here,
+# then there," not a tracked route. Endpoints are pinned to fixed plot centroids.
+# Returns list(edges, n_movers, n_tagged, n_plots, max_pair_m) or NULL.
+# ---------------------------------------------------------------------------
+plot_span_m <- function(cen) {
+  if (is.null(cen) || nrow(cen) < 2) return(0)
+  R <- 6371000; rad <- pi / 180; mx <- 0
+  for (i in 1:(nrow(cen) - 1)) for (j in (i + 1):nrow(cen)) {
+    dlat <- (cen$lat[j] - cen$lat[i]) * rad; dlng <- (cen$lng[j] - cen$lng[i]) * rad
+    a <- sin(dlat / 2)^2 + cos(cen$lat[i] * rad) * cos(cen$lat[j] * rad) * sin(dlng / 2)^2
+    mx <- max(mx, 2 * R * asin(min(1, sqrt(a))))
+  }
+  mx
+}
+
+recapture_edges <- function(d) {
+  h <- dplyr::filter(d, !is.na(.data$tagID), !is.na(.data$plotID), !is.na(.data$date),
+                     !is.na(.data$decimalLatitude), !is.na(.data$decimalLongitude))
+  if (nrow(h) == 0) return(NULL)
+  cen <- h %>% dplyr::group_by(.data$plotID) %>%
+    dplyr::summarise(lat = mean(.data$decimalLatitude), lng = mean(.data$decimalLongitude), .groups = "drop")
+  n_plots <- nrow(cen); n_tagged <- dplyr::n_distinct(h$tagID); span <- plot_span_m(cen)
+  seqs <- h %>% dplyr::arrange(.data$tagID, .data$date) %>%
+    dplyr::group_by(.data$tagID) %>% dplyr::summarise(ps = list(.data$plotID), .groups = "drop")
+  rows <- list(); movers <- character(0)
+  for (i in seq_len(nrow(seqs))) {
+    pl <- rle(as.character(seqs$ps[[i]]))$values   # drop consecutive same-plot repeats, keep A->B->A
+    if (length(pl) < 2) next
+    movers <- c(movers, seqs$tagID[i])
+    for (j in seq_len(length(pl) - 1)) {
+      key <- paste(sort(c(pl[j], pl[j + 1])), collapse = "||")
+      rows[[length(rows) + 1]] <- c(key = key, tag = as.character(seqs$tagID[i]))
+    }
+  }
+  base <- list(edges = NULL, n_movers = length(unique(movers)),
+               n_tagged = n_tagged, n_plots = n_plots, max_pair_m = span, cen = cen)
+  if (!length(rows)) return(base)
+  pr <- as.data.frame(do.call(rbind, rows), stringsAsFactors = FALSE)
+  agg <- pr %>% dplyr::group_by(.data$key) %>%
+    dplyr::summarise(n_movers = dplyr::n_distinct(.data$tag), .groups = "drop")
+  ab <- do.call(rbind, strsplit(agg$key, "||", fixed = TRUE))
+  ca <- cen[match(ab[, 1], cen$plotID), ]; cb <- cen[match(ab[, 2], cen$plotID), ]
+  base$edges <- data.frame(plot_a = ab[, 1], plot_b = ab[, 2],
+    lat0 = ca$lat, lng0 = ca$lng, lat1 = cb$lat, lng1 = cb$lng,
+    n_movers = agg$n_movers, stringsAsFactors = FALSE)
+  base
+}
+
+# Quadratic-Bezier arc points between two lon/lat endpoints (a curved connector,
+# so a line on a satellite tile never reads as a walked straight route). `bow`
+# offsets the control point perpendicular to the chord.
+arc_xy <- function(lng0, lat0, lng1, lat1, n = 24, bow = 0.18) {
+  mx <- (lng0 + lng1) / 2; my <- (lat0 + lat1) / 2
+  dx <- lng1 - lng0; dy <- lat1 - lat0
+  cx <- mx - dy * bow; cy <- my + dx * bow
+  t <- seq(0, 1, length.out = n)
+  list(lng = (1 - t)^2 * lng0 + 2 * (1 - t) * t * cx + t^2 * lng1,
+       lat = (1 - t)^2 * lat0 + 2 * (1 - t) * t * cy + t^2 * lat1)
+}
+
 # Population index: Minimum Number Known Alive (MNKA; Krebs 1966) + CPUE.
 # An individual is "known alive" in every monthly session between its first and
 # last capture in a plot (even sessions it was missed). Returns one row per

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -502,19 +502,19 @@ recapture_edges <- function(d) {
     if (length(pl) < 2) next
     movers <- c(movers, seqs$tagID[i])
     for (j in seq_len(length(pl) - 1)) {
-      key <- paste(sort(c(pl[j], pl[j + 1])), collapse = "||")
-      rows[[length(rows) + 1]] <- c(key = key, tag = as.character(seqs$tagID[i]))
+      ab <- sort(c(pl[j], pl[j + 1]))              # unordered pair as columns (no delimiter round-trip)
+      rows[[length(rows) + 1]] <- data.frame(a = ab[1], b = ab[2],
+        tag = as.character(seqs$tagID[i]), stringsAsFactors = FALSE)
     }
   }
   base <- list(edges = NULL, n_movers = length(unique(movers)),
                n_tagged = n_tagged, n_plots = n_plots, max_pair_m = span, cen = cen)
   if (!length(rows)) return(base)
-  pr <- as.data.frame(do.call(rbind, rows), stringsAsFactors = FALSE)
-  agg <- pr %>% dplyr::group_by(.data$key) %>%
+  pr <- do.call(rbind, rows)
+  agg <- pr %>% dplyr::group_by(.data$a, .data$b) %>%
     dplyr::summarise(n_movers = dplyr::n_distinct(.data$tag), .groups = "drop")
-  ab <- do.call(rbind, strsplit(agg$key, "||", fixed = TRUE))
-  ca <- cen[match(ab[, 1], cen$plotID), ]; cb <- cen[match(ab[, 2], cen$plotID), ]
-  base$edges <- data.frame(plot_a = ab[, 1], plot_b = ab[, 2],
+  ca <- cen[match(agg$a, cen$plotID), ]; cb <- cen[match(agg$b, cen$plotID), ]
+  base$edges <- data.frame(plot_a = agg$a, plot_b = agg$b,
     lat0 = ca$lat, lng0 = ca$lng, lat1 = cb$lat, lng1 = cb$lng,
     n_movers = agg$n_movers, stringsAsFactors = FALSE)
   base

--- a/manifest.json
+++ b/manifest.json
@@ -3251,7 +3251,7 @@
       "checksum": "162d6bde4c29749d2211ec8370b07f14"
     },
     "R/helpers.R": {
-      "checksum": "8af17ef1f974526f893b7d270ca4b6f5"
+      "checksum": "64c136484006a5b2856cf993d46cc064"
     },
     "R/report_pdf.R": {
       "checksum": "26051af6b58937aa9ddbb24899318201"
@@ -3260,7 +3260,7 @@
       "checksum": "dd998c7eb8763e4ae1f33c060ed8364a"
     },
     "server.R": {
-      "checksum": "95d2e923b899b7f26704f6d955fc4efa"
+      "checksum": "529b97fabcd973a9a6f5ff5d0b29fa5d"
     },
     "ui.R": {
       "checksum": "d7f6335f0280c5eeaedcce54532d3c14"

--- a/manifest.json
+++ b/manifest.json
@@ -3251,7 +3251,7 @@
       "checksum": "162d6bde4c29749d2211ec8370b07f14"
     },
     "R/helpers.R": {
-      "checksum": "43b911b70f48fa52b073e41f76a1ec9f"
+      "checksum": "8af17ef1f974526f893b7d270ca4b6f5"
     },
     "R/report_pdf.R": {
       "checksum": "26051af6b58937aa9ddbb24899318201"
@@ -3260,10 +3260,10 @@
       "checksum": "dd998c7eb8763e4ae1f33c060ed8364a"
     },
     "server.R": {
-      "checksum": "389c37cf9623e5e5980f1d393aea0654"
+      "checksum": "95d2e923b899b7f26704f6d955fc4efa"
     },
     "ui.R": {
-      "checksum": "85413fa01943c0ce92e3a358d707d6f2"
+      "checksum": "d7f6335f0280c5eeaedcce54532d3c14"
     },
     "www/app.js": {
       "checksum": "cf9fef6bdba15afc099cfb388b811ea9"
@@ -3284,7 +3284,7 @@
       "checksum": "03caa0fdc9353ecf3495715d7e5f11f5"
     },
     "www/styles.css": {
-      "checksum": "07d5c28ede1644057b2957986c664e89"
+      "checksum": "20b97f494b8df165232c89bd88f610b5"
     }
   },
   "users": null

--- a/server.R
+++ b/server.R
@@ -1470,6 +1470,59 @@ server <- function(input, output, session) {
       label = lapply(sprintf("⭐ selected individual here (%d caps)", hl$n), htmltools::HTML))
   })
 
+  # ---- between-plot recapture connectivity (the "movement" layer) ----------
+  recap_flow <- reactive({ d <- rv$data; if (is.null(d)) return(NULL); recapture_edges(d) })
+
+  # plain-English answer + the honest mark-recapture framing, above the map
+  output$mapInsight <- renderUI({
+    d <- rv$data; req(d)
+    rf <- recap_flow(); if (is.null(rf)) return(NULL)
+    if (rf$n_plots < 2)
+      return(insight_banner("diagram-2", tone = "muted",
+        "Only one trapping grid has coordinates here — there's no between-grid movement to map."))
+    if (rf$max_pair_m < 30)
+      return(insight_banner("diagram-2", tone = "muted",
+        HTML(sprintf("The grids here sit within <b>%d m</b> of each other — movement between them isn't resolvable at this scale.", round(rf$max_pair_m)))))
+    if (rf$n_movers == 0)
+      return(insight_banner("geo-fill", tone = "navy",
+        "No between-grid recaptures: every tagged animal stayed on its home grid (high site fidelity)."))
+    insight_banner("share-fill", tone = "navy",
+      HTML(sprintf("<span class='ci-hero'>%d</span> of %d tagged individuals were recaptured across <b>2+ grids</b>. Toggle <b>recapture movement</b> (top-right) to see the links — curved lines connect successive capture plots, <i>not</i> tracked routes.",
+        rf$n_movers, rf$n_tagged)))
+  })
+
+  # draw / clear the curved recapture arcs without redrawing the base map
+  observeEvent(list(input$showFlow, mapBase(), rv$tag), {
+    proxy <- leafletProxy("map") %>% clearGroup("flow") %>% clearGroup("flowSel")
+    if (!isTRUE(input$showFlow)) return()
+    rf <- recap_flow(); d <- rv$data
+    if (is.null(rf) || is.null(rf$edges) || !nrow(rf$edges) || rf$max_pair_m < 30) return()
+    e <- rf$edges; maxw <- max(e$n_movers)
+    for (i in seq_len(nrow(e))) {
+      a <- arc_xy(e$lng0[i], e$lat0[i], e$lng1[i], e$lat1[i])
+      frac <- if (maxw > 0) e$n_movers[i] / maxw else 1   # width+opacity carry weight (not hue) — CVD-safe
+      proxy %>% addPolylines(lng = a$lng, lat = a$lat, group = "flow",
+        weight = 1.8 + 5.5 * frac, opacity = 0.30 + 0.45 * frac, color = "#15b8a6",
+        label = htmltools::HTML(sprintf("%s &harr; %s<br/><b>%d</b> individuals moved between", e$plot_a[i], e$plot_b[i], e$n_movers[i])))
+    }
+    # selected individual's own successive-plot path, in gold, on top
+    tag <- rv$tag
+    if (!is.null(tag) && !is.null(rf$cen)) {
+      th <- d %>% dplyr::filter(.data$tagID == tag, !is.na(.data$plotID), !is.na(.data$date)) %>%
+        dplyr::arrange(.data$date)
+      pl <- if (nrow(th)) rle(as.character(th$plotID))$values else character(0)
+      cl <- rf$cen
+      for (j in seq_len(max(0, length(pl) - 1))) {
+        ra <- cl[match(pl[j], cl$plotID), ]; rb <- cl[match(pl[j + 1], cl$plotID), ]
+        if (nrow(ra) == 0 || nrow(rb) == 0 || is.na(ra$lat) || is.na(rb$lat)) next
+        a <- arc_xy(ra$lng, ra$lat, rb$lng, rb$lat)
+        proxy %>% addPolylines(lng = a$lng, lat = a$lat, group = "flowSel",
+          weight = 4, opacity = 0.95, color = "#c9a300",
+          label = htmltools::HTML(sprintf("selected: %s &rarr; %s", pl[j], pl[j + 1])))
+      }
+    }
+  }, ignoreNULL = FALSE)
+
   # ---- community pulse ----------------------------------------------------
   output$speciesBar <- renderPlotly({
     d <- rv$data; req(d)

--- a/server.R
+++ b/server.R
@@ -1487,15 +1487,17 @@ server <- function(input, output, session) {
       return(insight_banner("geo-fill", tone = "navy",
         "No between-grid recaptures: every tagged animal stayed on its home grid (high site fidelity)."))
     insight_banner("share-fill", tone = "navy",
-      HTML(sprintf("<span class='ci-hero'>%d</span> of %d tagged individuals were recaptured across <b>2+ grids</b>. Toggle <b>recapture movement</b> (top-right) to see the links — curved lines connect successive capture plots, <i>not</i> tracked routes.",
+      HTML(sprintf("<span class='ci-hero'>%d</span> of %d tagged individuals were recaptured across <b>2+ grids</b>. Toggle <b>recapture movement</b> (top-right) to see the links — curved lines connect successive capture plots, <i>not</i> tracked routes, and a link across a long time gap can reflect a reused ear tag.",
         rf$n_movers, rf$n_tagged)))
   })
 
-  # draw / clear the curved recapture arcs without redrawing the base map
-  observeEvent(list(input$showFlow, mapBase(), rv$tag), {
-    proxy <- leafletProxy("map") %>% clearGroup("flow") %>% clearGroup("flowSel")
+  # teal AGGREGATE layer — redraws only when the toggle or base map changes
+  # (kept separate from the gold layer so clicking a new individual doesn't
+  # flicker the whole network).
+  observeEvent(list(input$showFlow, mapBase()), {
+    proxy <- leafletProxy("map") %>% clearGroup("flow")
     if (!isTRUE(input$showFlow)) return()
-    rf <- recap_flow(); d <- rv$data
+    rf <- recap_flow()
     if (is.null(rf) || is.null(rf$edges) || !nrow(rf$edges) || rf$max_pair_m < 30) return()
     e <- rf$edges; maxw <- max(e$n_movers)
     for (i in seq_len(nrow(e))) {
@@ -1505,21 +1507,25 @@ server <- function(input, output, session) {
         weight = 1.8 + 5.5 * frac, opacity = 0.30 + 0.45 * frac, color = "#15b8a6",
         label = htmltools::HTML(sprintf("%s &harr; %s<br/><b>%d</b> individuals moved between", e$plot_a[i], e$plot_b[i], e$n_movers[i])))
     }
-    # selected individual's own successive-plot path, in gold, on top
-    tag <- rv$tag
-    if (!is.null(tag) && !is.null(rf$cen)) {
-      th <- d %>% dplyr::filter(.data$tagID == tag, !is.na(.data$plotID), !is.na(.data$date)) %>%
-        dplyr::arrange(.data$date)
-      pl <- if (nrow(th)) rle(as.character(th$plotID))$values else character(0)
-      cl <- rf$cen
-      for (j in seq_len(max(0, length(pl) - 1))) {
-        ra <- cl[match(pl[j], cl$plotID), ]; rb <- cl[match(pl[j + 1], cl$plotID), ]
-        if (nrow(ra) == 0 || nrow(rb) == 0 || is.na(ra$lat) || is.na(rb$lat)) next
-        a <- arc_xy(ra$lng, ra$lat, rb$lng, rb$lat)
-        proxy %>% addPolylines(lng = a$lng, lat = a$lat, group = "flowSel",
-          weight = 4, opacity = 0.95, color = "#c9a300",
-          label = htmltools::HTML(sprintf("selected: %s &rarr; %s", pl[j], pl[j + 1])))
-      }
+  }, ignoreNULL = FALSE)
+
+  # selected individual's own date-ordered path, in gold — redraws on tag change
+  observeEvent(list(rv$tag, input$showFlow, mapBase()), {
+    proxy <- leafletProxy("map") %>% clearGroup("flowSel")
+    if (!isTRUE(input$showFlow)) return()
+    tag <- rv$tag; d <- rv$data; rf <- recap_flow()
+    if (is.null(tag) || is.null(d) || is.null(rf) || is.null(rf$cen) || rf$max_pair_m < 30) return()
+    th <- d %>% dplyr::filter(.data$tagID == tag, !is.na(.data$plotID), !is.na(.data$date)) %>%
+      dplyr::arrange(.data$date)
+    pl <- if (nrow(th)) rle(as.character(th$plotID))$values else character(0)
+    cl <- rf$cen
+    for (j in seq_len(max(0, length(pl) - 1))) {
+      ra <- cl[match(pl[j], cl$plotID), ]; rb <- cl[match(pl[j + 1], cl$plotID), ]
+      if (is.na(ra$lat) || is.na(rb$lat)) next   # plot lacked coords -> skip the leg, don't fabricate it
+      a <- arc_xy(ra$lng, ra$lat, rb$lng, rb$lat)
+      proxy %>% addPolylines(lng = a$lng, lat = a$lat, group = "flowSel",
+        weight = 4, opacity = 0.95, color = "#c9a300",
+        label = htmltools::HTML(sprintf("selected: %s &rarr; %s", pl[j], pl[j + 1])))
     }
   }, ignoreNULL = FALSE)
 

--- a/ui.R
+++ b/ui.R
@@ -423,6 +423,7 @@ ui <- bslib::page_sidebar(
                  p("Each circle is a NEON trapping ", tags$b("plot"), ", placed at its real coordinates."),
                  p("Circle ", tags$b("size"), " = total captures there; ", tags$b("color"), " = species (same colors as the charts)."),
                  p("When an individual is selected, its plots get a pulsing ", tags$span(style="color:#ffd24a", "gold ring"), "."),
+                 p(tags$b("Recapture movement"), " (toggle, top-right): curved ", tags$span(style="color:#15b8a6", "teal arcs"), " link grids where the same tagged animals were recaptured — thicker = more individuals made that move. It's mark-recapture (\"here, then there\"), ", tags$b("not"), " a tracked route; a selected individual's own moves draw in gold."),
                  p("Hover a circle for its species + counts; switch basemap top-right."))),
             p("Each marker is a plot, sized by captures and colored by species. The selected individual's plots glow gold.")),
           div(class = "map-controls",
@@ -432,9 +433,12 @@ ui <- bslib::page_sidebar(
                                     "Light" = "CartoDB.Positron",
                                     "Dark" = "CartoDB.DarkMatter")),
             sliderInput("rad_size", "Marker scale", min = .3, max = 2.5, value = 1, step = .1, width = "150px"),
+            div(class = "map-flow-toggle",
+              checkboxInput("showFlow", tagList(bs_icon("share-fill"), " Recapture movement"), value = FALSE)),
             actionButton("reloadMapBtn", tagList(bs_icon("arrow-clockwise"), " Redraw"),
                          class = "btn-outline-dark btn-sm"))
         ),
+        uiOutput("mapInsight"),
         spin(leafletOutput("map", height = "620px"), img = "rat1.gif")
       ),
 

--- a/www/styles.css
+++ b/www/styles.css
@@ -314,7 +314,12 @@ body {
 /* "tap me" hint under an interactive chart */
 .chart-hint { color: var(--muted); font-size: 12px; margin: 0 4px 6px; display: flex; align-items: center; gap: 6px; }
 .chart-hint .bi { color: var(--gold-ink); }
-.map-controls { display: flex; gap: 14px; align-items: flex-end; }
+.map-controls { display: flex; gap: 14px; align-items: flex-end; flex-wrap: wrap; }
+/* the recapture-movement checkbox sits inline in the map control bar */
+.map-flow-toggle { margin-bottom: 6px; }
+.map-flow-toggle .form-group, .map-flow-toggle .checkbox { margin: 0; }
+.map-flow-toggle .form-check-label, .map-flow-toggle label { font-size: 13px; font-weight: 600; color: var(--ink); white-space: nowrap; }
+.map-flow-toggle .bi { color: #15b8a6; }
 /* inline "Tracking" individual picker in the Home Range tab head */
 .hr-controls { display: flex; gap: 18px; align-items: flex-end; flex-wrap: wrap; }
 .hr-indiv { display: flex; flex-direction: column; gap: 3px; }


### PR DESCRIPTION
Redesigns the Plot map from a dot map into a **between-plot movement network** — the #1 concept Atlas + Sarah independently converged on (the recapture-movement signal was computed and thrown away as a scalar).

## What it shows
An opt-in **"Recapture movement"** toggle draws curved **teal arcs** linking grids where the same tagged animals were recaptured — **width + opacity** (not hue → CVD-safe) = how many individuals made each move. A selected individual's own moves draw in **gold** on top. Drawn via `leafletProxy` (no base-map rebuild).

## Honesty (it's mark-recapture, not telemetry)
- `mapInsight` banner: *"N of M tagged individuals were recaptured across 2+ grids … curved lines connect successive capture plots, **not** tracked routes."*
- **Curved** arcs (quadratic Bézier) so a line never reads as a walked straight route on satellite tiles.
- Gated to a muted note when: only one grid has coords; grids sit **<30 m** apart (movement unresolvable at scale); or **zero** between-grid movement (→ "high site fidelity," a real finding, not an empty map).
- Endpoints pinned to fixed plot centroids (no jitter between redraws).

## Build
Plugin-free (`recapture_edges()` + `arc_xy()` in helpers.R) — **no new dependency**, zero Connect Cloud deploy risk (your call).

## Verification (JORN demo)
- ✅ banner: "14 of 2252 recaptured across 2+ grids"
- ✅ toggle on → 8 curved teal arcs; toggle off → cleanly cleared
- ✅ no server errors; screenshot shows arcs over the satellite basemap

🤖 Generated with [Claude Code](https://claude.com/claude-code)