### PR TITLE
feat: Hall of Fame podium + dossier story-hero (fun-page polish)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3260,13 +3260,13 @@
       "checksum": "dd998c7eb8763e4ae1f33c060ed8364a"
     },
     "server.R": {
-      "checksum": "529b97fabcd973a9a6f5ff5d0b29fa5d"
+      "checksum": "4b789f27c34d0ec48e6a6d6b0f264e5d"
     },
     "ui.R": {
-      "checksum": "d7f6335f0280c5eeaedcce54532d3c14"
+      "checksum": "3750d597fc423f3ad6518b405c921846"
     },
     "www/app.js": {
-      "checksum": "cf9fef6bdba15afc099cfb388b811ea9"
+      "checksum": "27b51557f767db76b5b387aff1f0efe3"
     },
     "www/confirm.js": {
       "checksum": "c05030299121b6bb32e2794f0decb120"
@@ -3284,7 +3284,7 @@
       "checksum": "03caa0fdc9353ecf3495715d7e5f11f5"
     },
     "www/styles.css": {
-      "checksum": "20b97f494b8df165232c89bd88f610b5"
+      "checksum": "37224206061a92a501fcd83b44fbc15b"
     }
   },
   "users": null

--- a/manifest.json
+++ b/manifest.json
@@ -3260,7 +3260,7 @@
       "checksum": "dd998c7eb8763e4ae1f33c060ed8364a"
     },
     "server.R": {
-      "checksum": "4b789f27c34d0ec48e6a6d6b0f264e5d"
+      "checksum": "1264cd737dc26a1217963d06d5c058c9"
     },
     "ui.R": {
       "checksum": "3750d597fc423f3ad6518b405c921846"

--- a/server.R
+++ b/server.R
@@ -980,11 +980,14 @@ server <- function(input, output, session) {
     v <- rv$lb_view; req(v)
     cat_key <- input$leaderCat %||% "captures"
 
-    medal <- function(rank) paste0("#", rank)
+    mdl3 <- c("\U0001F947", "\U0001F948", "\U0001F949")   # gold / silver / bronze
+    medal <- function(rank) if (rank <= 3)
+      sprintf("<span class='medal'>%s</span> %d", mdl3[rank], rank) else paste0("#", rank)
     rar_badge <- function(tier) {
       m <- lapply(tier, rarity_meta)
       vapply(seq_along(tier), function(i) sprintf(
-        "<span class='tag-badge' style='background:%s;border-color:%s;color:#fff'>%s %s</span>",
+        "<span class='tag-badge%s' style='background:%s;border-color:%s;color:#fff'>%s %s</span>",
+        if (tier[i] == "Legendary") " is-legendary" else "",
         m[[i]]$color, m[[i]]$color, m[[i]]$icon, tier[i]), character(1))
     }
     chonk_badge <- function(tier, pct) {
@@ -1017,6 +1020,51 @@ server <- function(input, output, session) {
                                             targets = c(0, 2, 3, 4, 5, 6, 7, 8, 9))),
                      language = list(search = "", searchPlaceholder = "filter individuals…"))
     )
+  })
+
+  # category-switch banner: names the current leader so re-ranking has a payoff
+  output$leaderBanner <- renderUI({
+    v <- rv$lb_view; req(v); if (nrow(v) == 0) return(NULL)
+    cat_key <- input$leaderCat %||% "captures"; lead <- v[1, ]
+    lab <- switch(cat_key, captures = "most-caught", weight = "heaviest",
+                  career = "longest-tenured", roam = "furthest-roaming", chonk = "chonkiest", "top")
+    val <- switch(cat_key,
+      captures = paste0(fmt_int(lead$captures), " captures"),
+      weight   = ifelse(is.na(lead$max_weight), "—", paste0(lead$max_weight, " g")),
+      career   = ifelse(lead$career_days > 0, paste0(lead$career_days, " days"), "—"),
+      roam     = ifelse(is.na(lead$roam_m), "—", paste0(lead$roam_m, " m")),
+      chonk    = ifelse(is.na(lead$chonk_pct), "—", paste0(round(lead$chonk_pct), "% weight-for-species")),
+      "")
+    insight_banner("trophy-fill", tone = "gold",
+      HTML(sprintf("The <b>%s</b> animal at this site is <span class='ci-hero'>%s</span> (<i>%s</i>) — %s.",
+        lab, lead$short, lead$scientificName, val)))
+  })
+
+  # top-3 podium (olympic layout: 2nd · 1st-raised · 3rd), clickable to dossiers
+  output$famePodium <- renderUI({
+    v <- rv$lb_view; req(v); if (nrow(v) == 0) return(NULL)
+    cat_key <- input$leaderCat %||% "captures"
+    big_stat <- function(r) switch(cat_key,
+      captures = paste0(fmt_int(r$captures), " caps"),
+      weight   = ifelse(is.na(r$max_weight), "—", paste0(r$max_weight, " g")),
+      career   = ifelse(r$career_days > 0, paste0(r$career_days, " d"), "—"),
+      roam     = ifelse(is.na(r$roam_m), "—", paste0(r$roam_m, " m")),
+      chonk    = ifelse(is.na(r$chonk_pct), "—", paste0(round(r$chonk_pct), "%")),
+      paste0(fmt_int(r$captures), " caps"))
+    top <- utils::head(v, 3)
+    pos_order <- if (nrow(top) >= 3) c(2L, 1L, 3L) else seq_len(nrow(top))
+    cards <- lapply(pos_order, function(i) {
+      r <- top[i, ]; rm <- rarity_meta(r$rarity)
+      div(class = paste0("podium-card podium-", i, if (r$rarity == "Legendary") " is-legendary" else ""),
+        style = sprintf("--rc:%s", rm$color),
+        onclick = sprintf("Shiny.setInputValue('modalPick','%s',{priority:'event'})", r$tagID),
+        div(class = "podium-medal", c("\U0001F947", "\U0001F948", "\U0001F949")[i]),
+        div(class = "podium-emoji", r$emoji),
+        div(class = "podium-id", r$short),
+        div(class = "podium-stat", big_stat(r)),
+        div(class = "podium-sp", em(r$scientificName)))
+    })
+    div(class = "podium", cards)
   })
 
   # ---- bio repository links ----------------------------------------------
@@ -1058,10 +1106,28 @@ server <- function(input, output, session) {
     rm <- rarity_meta(row$rarity[1])
     nick <- if (!is.na(row$nickname[1])) row$nickname[1] else "small mammal"
 
-    stat <- function(value, label) div(class = "ds-stat",
-      div(class = "ds-stat-v", value), div(class = "ds-stat-l", label))
-
+    # numeric stat tiles animate via the shared count-up engine (data-target +
+    # optional unit suffix); non-numeric tiles (home plot) render plain.
+    stat <- function(label, target = NA, suffix = "", fallback = "—") {
+      v <- if (length(target) == 1 && !is.na(target) && is.finite(target))
+        tags$span(class = "count-up", `data-target` = target, `data-suffix` = suffix, "0")
+      else fallback
+      div(class = "ds-stat", div(class = "ds-stat-v", v), div(class = "ds-stat-l", label))
+    }
     fmt_date <- function(x) if (is.na(x)) "—" else format(x, "%b %Y")
+
+    # one computed "story" sentence, with the lead stat ranked against peers
+    lb <- rv$lb; ntot <- nrow(lb)
+    cap_rank <- sum(lb$captures > row$captures[1], na.rm = TRUE) + 1L
+    rank_phrase <- if (cap_rank == 1) "the most-caught individual at this site"
+      else if (cap_rank <= max(2, ceiling(0.05 * ntot))) sprintf("in the top %d%% by captures here", max(1L, round(100 * cap_rank / ntot)))
+      else sprintf("#%d of %d by captures here", cap_rank, ntot)
+    art <- if (grepl("^[AEIOU]", row$rarity[1])) "an" else "a"
+    ci_tone <- switch(row$rarity[1], Legendary = "gold", Epic = "terra", Rare = "navy", Uncommon = "pine", "muted")
+    story <- sprintf("<b>%s</b> is %s <b>%s</b> resident — caught <span class='ci-hero'>%s</span> times%s, %s.",
+      row$short[1], art, row$rarity[1], fmt_int(row$captures[1]),
+      if (row$career_days[1] > 0) sprintf(" over %s days", fmt_int(row$career_days[1])) else "",
+      rank_phrase)
 
     div(class = "dossier-card", style = sprintf("--rarity:%s; --rglow:%s;", rm$color, rm$glow),
       div(class = "ds-left",
@@ -1080,13 +1146,14 @@ server <- function(input, output, session) {
                  bs_icon("question-circle-fill"), " ID uncertain")
         ),
         div(class = "ds-sci", em(row$scientificName[1])),
+        insight_banner("stars", tone = ci_tone, HTML(story)),
         div(class = "ds-stats",
-          stat(row$captures[1], "captures"),
-          stat(ifelse(row$career_days[1] > 0, paste0(row$career_days[1], "d"), "—"), "career span"),
-          stat(row$n_traps[1], "traps used"),
-          stat(ifelse(is.na(row$mdm_m[1]), "—", paste0(row$mdm_m[1], "m")), "max move"),
-          stat(ifelse(is.na(row$avg_weight[1]), "—", paste0(row$avg_weight[1], "g")), "avg weight"),
-          stat(row$home_plot[1], "home plot")
+          stat("captures", target = row$captures[1]),
+          stat("career span", target = if (row$career_days[1] > 0) row$career_days[1] else NA, suffix = "d"),
+          stat("traps used", target = row$n_traps[1]),
+          stat("max move", target = row$mdm_m[1], suffix = "m"),
+          stat("avg weight", target = row$avg_weight[1], suffix = "g"),
+          stat("home plot", fallback = row$home_plot[1])
         ),
         div(class = "ds-meta",
           span(bs_icon("calendar-event"), " First seen ", tags$b(fmt_date(row$first_seen[1]))),

--- a/server.R
+++ b/server.R
@@ -1119,7 +1119,9 @@ server <- function(input, output, session) {
     # one computed "story" sentence, with the lead stat ranked against peers
     lb <- rv$lb; ntot <- nrow(lb)
     cap_rank <- sum(lb$captures > row$captures[1], na.rm = TRUE) + 1L
-    rank_phrase <- if (cap_rank == 1) "the most-caught individual at this site"
+    n_tied_top <- sum(lb$captures == row$captures[1], na.rm = TRUE)   # don't crown two tied animals
+    rank_phrase <- if (cap_rank == 1 && n_tied_top == 1) "the most-caught individual at this site"
+      else if (cap_rank == 1) sprintf("tied for most-caught at this site (%d-way)", n_tied_top)
       else if (cap_rank <= max(2, ceiling(0.05 * ntot))) sprintf("in the top %d%% by captures here", max(1L, round(100 * cap_rank / ntot)))
       else sprintf("#%d of %d by captures here", cap_rank, ntot)
     art <- if (grepl("^[AEIOU]", row$rarity[1])) "an" else "a"

--- a/ui.R
+++ b/ui.R
@@ -474,8 +474,10 @@ ui <- bslib::page_sidebar(
           tags$span(class = "rl-sep", "·"),
           tags$span(class = "rl-label", style = "letter-spacing:0;text-transform:none;",
                     "by total captures (15+ → Legendary)")),
+        uiOutput("leaderBanner"),
+        uiOutput("famePodium"),
         div(class = "tab-intro", bs_icon("hand-index-thumb"),
-            " Tap any row to open that animal's dossier — measurements, home range, capture history, and a shareable card."),
+            " Tap any row (or a podium card) to open that animal's dossier — measurements, home range, capture history, and a shareable card."),
         spin(DT::DTOutput("leaderboard"))
       ),
 

--- a/www/app.js
+++ b/www/app.js
@@ -11,16 +11,21 @@ function animateCount(el) {
   // custom Shiny message, which doesn't always register in time).
   if (typeof smtLoadDone === "function") smtLoadDone();
   const target = parseFloat(el.getAttribute("data-target")) || 0;
+  const suffix = el.dataset.suffix || "";          // e.g. "d", "m", "g"
   const isFloat = !Number.isInteger(target);
+  const fmt = (v) => (isFloat ? v.toFixed(1) : Math.round(v).toLocaleString()) + suffix;
+  // reduced-motion: snap to the final value, no animation
+  if (window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    el.textContent = fmt(target); return;
+  }
   const dur = 900;
   const start = performance.now();
   function tick(now) {
     const t = Math.min(1, (now - start) / dur);
     const eased = 1 - Math.pow(1 - t, 3); // easeOutCubic
-    const val = target * eased;
-    el.textContent = isFloat ? val.toFixed(1) : Math.round(val).toLocaleString();
+    el.textContent = fmt(target * eased);
     if (t < 1) requestAnimationFrame(tick);
-    else el.textContent = isFloat ? target.toFixed(1) : Math.round(target).toLocaleString();
+    else el.textContent = fmt(target);
   }
   requestAnimationFrame(tick);
 }

--- a/www/styles.css
+++ b/www/styles.css
@@ -851,3 +851,43 @@ table.dataTable tbody tr:active { background: #dfe8f4 !important; }
 
 /* counters pop in */
 .count-up { display: inline-block; }
+
+/* ---- Hall of Fame podium (top-3, olympic: 2nd · 1st-raised · 3rd) ------ */
+.podium { display: flex; justify-content: center; align-items: flex-end; gap: 14px; margin: 4px 0 16px; }
+.podium-card { flex: 1 1 0; max-width: 230px; min-width: 0; text-align: center; cursor: pointer;
+  border: 1px solid var(--line); border-top: 4px solid var(--rc, var(--muted)); border-radius: 14px;
+  padding: 14px 12px 12px; background: var(--paper); box-shadow: 0 4px 14px -8px rgba(12, 35, 75, .3);
+  transition: transform .15s, box-shadow .15s; animation: podiumRise .5s cubic-bezier(.2, .7, .3, 1) both; }
+.podium-card:hover { transform: translateY(-4px); box-shadow: 0 10px 24px -10px rgba(12, 35, 75, .45); }
+.podium-1 { padding-top: 22px; box-shadow: 0 6px 22px -8px var(--rc); animation-delay: .18s; }
+.podium-2 { animation-delay: 0s; } .podium-3 { animation-delay: .09s; }
+.podium-medal { font-size: 26px; line-height: 1; }
+.podium-1 .podium-medal { font-size: 32px; }
+.podium-emoji { font-size: 34px; line-height: 1.15; }
+.podium-id { font-family: "Jura", monospace; font-weight: 800; color: var(--ink); font-size: 14px; margin-top: 2px; }
+.podium-stat { font-weight: 800; color: var(--rc, var(--ink)); font-size: 15px; }
+.podium-1 .podium-stat { font-size: 18px; }
+.podium-sp { font-size: 10.5px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+@keyframes podiumRise { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: none; } }
+[data-bs-theme="dark"] .podium-card { background: #16213a; }
+.leader-dt .medal { font-size: 15px; }
+@media (max-width: 560px) { .podium-sp { display: none; } .podium-emoji { font-size: 28px; } .podium { gap: 8px; } }
+
+/* ---- Legendary living shimmer (capped to the top tier only) ----------- */
+.tag-badge.is-legendary, .podium-card.is-legendary { position: relative; overflow: hidden; }
+.tag-badge.is-legendary::after, .podium-card.is-legendary::after {
+  content: ""; position: absolute; inset: 0; pointer-events: none;
+  background: linear-gradient(115deg, transparent 30%, rgba(255, 255, 255, .55) 50%, transparent 70%);
+  transform: translateX(-130%); animation: legShimmer 2.8s ease-in-out infinite; }
+@keyframes legShimmer { 0% { transform: translateX(-130%); } 55%, 100% { transform: translateX(130%); } }
+
+/* dossier rarity badge "card-pull" pop on open */
+.dossier-card .glow-badge { animation: badgePop .5s cubic-bezier(.2, .8, .3, 1.2) both; }
+@keyframes badgePop { from { opacity: 0; transform: scale(.6); } to { opacity: 1; transform: none; } }
+
+/* ---- reduced-motion: kill every decorative animation (incl. the float
+   that previously ran unconditionally on .ds-emoji) -------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .ds-emoji, .podium-card, .dossier-card .glow-badge { animation: none !important; }
+  .tag-badge.is-legendary::after, .podium-card.is-legendary::after { animation: none; opacity: 0; }
+}


### PR DESCRIPTION
The "fun pages" (Hall of Fame + Dossier), from the Wes + Alyssa brainstorm — turning two flat reference tables into stories, with dynamic (reduced-motion-gated) styling.

## Hall of Fame
- **Top-3 podium** above the leaderboard (olympic 2nd · 1st-raised · 3rd) — each card clickable to its dossier, reshuffles on category change with a staggered rise-in.
- **Category-switch banner** naming the current leader (re-ranking now has a payoff).
- **Medal glyphs** 🥇🥈🥉 in the top-3 rank cells.

## Dossier
- A computed **"story" hero sentence** with the lead stat ranked against peers — *"908946 is a Legendary resident — caught 38 times over 1,119 days, the most-caught individual at this site"* — toned by rarity.
- Stat tiles **count up** on open (added `data-suffix` to the shared engine so `1,119d` / `64m` / `15.8g` animate with units).
- **Card-pull pop** on the rarity badge.

## Dynamic styling (all reduced-motion-gated)
- **Legendary-only living shimmer** on the rarity badge + podium card.
- **Fix:** the `.ds-emoji` float keyframe was running *unconditionally* — now gated, along with every new animation, under `prefers-reduced-motion`.

## Verification (JORN demo)
- ✅ 3-card podium centered on the 38-cap leader; category banner; 3 rank medals; 15 Legendary shimmer badges
- ✅ Dossier hero sentence + count-up tiles (38 / 1,119d / 16 / 64m / 15.8g); screenshot confirms the gold story banner + animated tiles
- ✅ No server errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)