### PR TITLE
feat: env picker on Population tab + report-card PDF header fix

### DIFF
--- a/R/report_pdf.R
+++ b/R/report_pdf.R
@@ -191,11 +191,15 @@ new_page <- function(page_i, title, footer_full = FALSE) {
   grid.newpage()
   pushViewport(viewport(width = unit(PG$cw, "in"), height = unit(PG$ch, "in"), name = "content"))
   if (page_i > 1) {
-    grid.text(ascii(title), x = unit(0, "npc"), y = gy(0), just = c("left", "top"),
+    # truncate a long site label so the running header never collides with the
+    # right-corner title (e.g. UNDE = "University of Notre Dame Environmental
+    # Research Center" used to run straight into it).
+    hl <- ascii(title); if (nchar(hl) > 50) hl <- paste0(substr(hl, 1, 49), "…")
+    grid.text(hl, x = unit(0, "npc"), y = gy(0), just = c("left", "top"),
               gp = gpar(fontsize = 10, fontface = "bold", col = PG$navy))
     grid.text("NEON Small Mammal Report Card", x = unit(1, "npc"), y = gy(0),
               just = c("right", "top"), gp = gpar(fontsize = 8.5, col = PG$muted))
-    grid.lines(x = unit(c(0, 1), "npc"), y = gy(0.22), gp = gpar(col = PG$line, lwd = 1))
+    grid.lines(x = unit(c(0, 1), "npc"), y = gy(0.24), gp = gpar(col = PG$line, lwd = 1))
   }
   ftxt <- if (footer_full)
     paste(FOOT, "MNKA = Minimum Number Known Alive (Krebs 1966); Hill numbers (Jost 2006);",

--- a/manifest.json
+++ b/manifest.json
@@ -3254,7 +3254,7 @@
       "checksum": "64c136484006a5b2856cf993d46cc064"
     },
     "R/report_pdf.R": {
-      "checksum": "26051af6b58937aa9ddbb24899318201"
+      "checksum": "c56a3f565ebf018dc7ce32dd37778fbb"
     },
     "R/site_metadata.R": {
       "checksum": "dd998c7eb8763e4ae1f33c060ed8364a"
@@ -3263,7 +3263,7 @@
       "checksum": "5b4903850be4a9c444864957ef6afc4e"
     },
     "ui.R": {
-      "checksum": "3750d597fc423f3ad6518b405c921846"
+      "checksum": "f7166f43709d9f1e4f5412720c69cc75"
     },
     "www/app.js": {
       "checksum": "27b51557f767db76b5b387aff1f0efe3"
@@ -3284,7 +3284,7 @@
       "checksum": "03caa0fdc9353ecf3495715d7e5f11f5"
     },
     "www/styles.css": {
-      "checksum": "37224206061a92a501fcd83b44fbc15b"
+      "checksum": "02448f4f541acb9a8b2e17d01f5bddea"
     }
   },
   "users": null

--- a/ui.R
+++ b/ui.R
@@ -94,31 +94,9 @@ ui <- bslib::page_sidebar(
       uiOutput("bioLinks")
     )),
 
-    # ---- compare with environment (co-located NEON products) --------------
-    hidden(div(id = "envPickerWrap",
-      hr(class = "deck-hr"),
-      selectInput("envLayer",
-        label = tagList(bs_icon("cloud-drizzle-fill"), " Compare with environment",
-          info_pop("Environmental overlays",
-            p("Overlay a co-located NEON data product — measured at ", tags$b("this same site"),
-              " — behind the population & seasonality charts to see what the booms and busts track."),
-            tags$ul(
-              tags$li(tags$b("Precipitation"), " — the rain pulse that feeds desert seed crops"),
-              tags$li(tags$b("Air temperature"), " — thermal limits on activity & plant growth"),
-              tags$li(tags$b("Plants flowering"), " — the annual seed-crop precursor granivores key on"),
-              tags$li(tags$b("Green-up (leaf-out)"), " — forage & cover, and an early precip-pulse proxy"),
-              tags$li(tags$b("Plants fruiting"), " — a near-direct food-supply signal (mast at forest sites)")),
-            p("Picking a layer shows it at its ", tags$b("most-correlated lag"), " by default; use the ", tags$b("lag"), " slider to shift the driver forward in time and explore other lags — a rain pulse can take months to become a rodent boom (the classic desert ", tags$em("pulse–reserve"), " response; Noy-Meir 1973; Brown & Ernest 2002)."),
-            p(class = "pop-caveat", bs_icon("exclamation-triangle"),
-              tags$b(" These overlays show correlation, not proof of cause."),
-              " Drivers are often correlated with each other (warm months are also dry months), so read a strong match as a lead to investigate, not a settled mechanism."))),
-        choices = c("None" = "none"), width = "100%"),
-      div(id = "envLagWrap",
-        sliderInput("envLag", tagList(bs_icon("hourglass-split"), " Lead time (months)"),
-                    min = 0, max = 12, value = 0, step = 1, width = "100%"),
-        div(class = "env-lag-hint", "0 = same month · 3 = driver 3 months earlier")),
-      uiOutput("envSourceNote")
-    )),
+    # ("Compare with environment" was moved out of the sidebar and onto the
+    #  Population tab — see envPickerWrap there — so it's actually discoverable
+    #  right where its overlays live.)
 
     hr(class = "deck-hr"),
     actionButton("help", tagList(bs_icon("question-circle"), " How it works"),
@@ -274,6 +252,34 @@ ui <- bslib::page_sidebar(
             h4("Defensible population signals"),
             p("Minimum Number Known Alive (MNKA) and catch-per-unit-effort are honest abundance indices; the accumulation curve shows whether trapping ran long enough to find every species."))
         ),
+        # "Compare with environment" lives HERE (moved off the sidebar) so it's
+        # discoverable right where its overlays appear. Hidden until the site has
+        # env data; choices + show/hide are driven server-side by id.
+        hidden(div(id = "envPickerWrap", class = "env-pop-bar",
+          div(class = "env-pop-row",
+            div(class = "env-pop-sel",
+              selectInput("envLayer",
+                label = tagList(bs_icon("cloud-drizzle-fill"), " Compare with environment",
+                  info_pop("Environmental overlays",
+                    p("Overlay a co-located NEON data product — measured at ", tags$b("this same site"),
+                      " — behind the population & seasonality charts to see what the booms and busts track."),
+                    tags$ul(
+                      tags$li(tags$b("Precipitation"), " — the rain pulse that feeds desert seed crops"),
+                      tags$li(tags$b("Air temperature"), " — thermal limits on activity & plant growth"),
+                      tags$li(tags$b("Plants flowering"), " — the annual seed-crop precursor granivores key on"),
+                      tags$li(tags$b("Green-up (leaf-out)"), " — forage & cover, and an early precip-pulse proxy"),
+                      tags$li(tags$b("Plants fruiting"), " — a near-direct food-supply signal (mast at forest sites)")),
+                    p("Picking a layer shows it at its ", tags$b("most-correlated lag"), " by default; use the ", tags$b("lag"), " slider to shift the driver forward in time and explore other lags — a rain pulse can take months to become a rodent boom (the classic desert ", tags$em("pulse–reserve"), " response; Noy-Meir 1973; Brown & Ernest 2002)."),
+                    p(class = "pop-caveat", bs_icon("exclamation-triangle"),
+                      tags$b(" These overlays show correlation, not proof of cause."),
+                      " Drivers are often correlated with each other (warm months are also dry months), so read a strong match as a lead to investigate, not a settled mechanism."))),
+                choices = c("None" = "none"), width = "100%")),
+            div(id = "envLagWrap", class = "env-pop-lag",
+              sliderInput("envLag", tagList(bs_icon("hourglass-split"), " Lead time (months)"),
+                          min = 0, max = 12, value = 0, step = 1, width = "100%"),
+              div(class = "env-lag-hint", "0 = same month · 3 = driver 3 months earlier"))),
+          uiOutput("envSourceNote")
+        )),
         conditionalPanel("output.hasEnv == true",
           card(full_screen = TRUE,
             card_head("bar-chart-steps", "Which environmental driver does this population track best?",

--- a/www/styles.css
+++ b/www/styles.css
@@ -89,6 +89,15 @@ body {
 .prov-hint { font-size: 11px; color: var(--muted); line-height: 1.4; margin-top: 2px; }
 
 /* ---- "compare with environment" overlay picker ----------------------- */
+/* control bar now lives on the Population tab (was the sidebar) */
+.env-pop-bar { border: 1px solid var(--line); border-left: 4px solid var(--pine); border-radius: 12px;
+  padding: 12px 16px; margin: 0 0 14px; background: linear-gradient(180deg, #f4f8fd 0%, var(--paper) 100%); }
+.env-pop-row { display: flex; gap: 20px; align-items: flex-end; flex-wrap: wrap; }
+.env-pop-sel { flex: 2 1 300px; min-width: 240px; }
+.env-pop-lag { flex: 1 1 220px; min-width: 190px; }
+.env-pop-bar .form-group, .env-pop-bar .shiny-input-container { margin-bottom: 0; }
+[data-bs-theme="dark"] .env-pop-bar { background: linear-gradient(180deg, #1b2942 0%, var(--paper) 100%); }
+@media (max-width: 560px) { .env-pop-row { gap: 6px; } }
 .env-lag-hint { font-size: 10.5px; color: var(--muted); line-height: 1.35; margin: -6px 0 4px; }
 .env-source { display: flex; gap: 7px; align-items: flex-start; font-size: 11px; line-height: 1.4;
   border-radius: 8px; padding: 7px 9px; margin-top: 4px; }


### PR DESCRIPTION
Two of the requested items (the quick, confirmed ones):

## 1. "Compare with environment" moved onto the Population tab
It was hidden in the sidebar — easy to miss (you did!). Now it's a visible control bar (driver select + lag slider, side-by-side) at the top of the Population tab, right where its overlays appear. Same input ids, so every overlay still works.
- ✅ Verified: selecting a layer renders the env-response scatter, shows the "Live from co-located NEON sensors" source note, and updates the detection-plot overlay; the control is gone from the sidebar.

## 2. Report-card PDF header overlap — fixed
Confirmed the cause: a **long site name** in the page-2+ running header collided with the right-corner "NEON Small Mammal Report Card" (reproduced with UNDE — "University of Notre Dame Environmental Research Center"). JORN/SCBI rendered fine; UNDE overlapped. Now the running-header label is truncated to 50 chars so it can never collide.

---
Still to come (separate PRs): a **species measurement profile**, the **sample-count** idea (needs a data re-bundle — those columns were trimmed; see my message), and the **two-site comparison report**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)