### PR TITLE
feat: two-site comparison report (PDF)

### DIFF
--- a/R/report_pdf.R
+++ b/R/report_pdf.R
@@ -353,3 +353,96 @@ render_report_pdf <- function(file, d, label, is_demo = FALSE, cc = NULL) {
   popViewport()
   invisible(file)
 }
+
+# ---- two-site comparison report -------------------------------------------
+# Side-by-side PDF for two sites: a winner-highlighted metric table, species
+# overlap, top species per site, and (if ggplot2) composition charts on page 2.
+render_compare_pdf <- function(file, dA, labelA, dB, labelB) {
+  pack <- function(d) list(
+    cs = community_stats(d), hn = hill_numbers(d),
+    sp = utils::head(species_summary(d), 6),
+    all_sp = sort(unique(species_level_only(dplyr::filter(d, !is.na(.data$scientificName)))$scientificName)))
+  A <- pack(dA); B <- pack(dB)
+  codeA <- sub("[ ].*$", "", labelA); codeB <- sub("[ ].*$", "", labelB)
+  has_gg <- requireNamespace("ggplot2", quietly = TRUE)
+
+  PDF_DEV(file, width = PG$w, height = PG$h, onefile = TRUE)
+  on.exit(grDevices::dev.off(), add = TRUE)
+
+  new_page(1, "")
+  y <- 0.05
+  grid.text(ascii("Two-site comparison"), x = unit(0, "npc"), y = gy(y),
+            just = c("left", "top"), gp = gpar(fontsize = 20, fontface = "bold", col = PG$navy))
+  y <- y + 0.36
+  grid.text(ascii(sprintf("%s   vs   %s", labelA, labelB)), x = unit(0, "npc"), y = gy(y),
+            just = c("left", "top"), gp = gpar(fontsize = 11, col = PG$muted))
+  y <- y + 0.44
+
+  cax <- 0.58; cbx <- 0.79
+  grid.text("Metric", x = unit(0, "npc"), y = gy(y), just = c("left", "top"), gp = gpar(fontface = "bold", fontsize = 10, col = PG$navy))
+  grid.text(ascii(codeA), x = unit(cax, "npc"), y = gy(y), just = c("left", "top"), gp = gpar(fontface = "bold", fontsize = 10, col = PG$navy))
+  grid.text(ascii(codeB), x = unit(cbx, "npc"), y = gy(y), just = c("left", "top"), gp = gpar(fontface = "bold", fontsize = 10, col = PG$navy))
+  grid.lines(x = unit(c(0, 1), "npc"), y = gy(y + 0.19), gp = gpar(col = PG$line, lwd = 1))
+  y <- y + 0.30
+  mrow <- function(lab, va, vb, fmt = function(x) format(round(x), big.mark = ","), higher = TRUE) {
+    tie <- is.na(va) || is.na(vb) || va == vb
+    aw <- !tie && ((va > vb) == higher); bw <- !tie && !aw && !(va == vb)
+    list(lab = lab, sa = fmt(va), sb = fmt(vb), fa = if (aw) 2 else 1, fb = if (bw) 2 else 1)
+  }
+  rows <- list(
+    mrow("Captures", A$cs$total_captures, B$cs$total_captures),
+    mrow("Individuals", A$cs$individuals, B$cs$individuals),
+    mrow("Species (richness)", A$cs$species, B$cs$species),
+    mrow("Effective common species (Hill q1)", A$hn$q1, B$hn$q1, fmt = function(x) format(round(x, 1), nsmall = 1)),
+    mrow("Evenness (0-1)", A$hn$even, B$hn$even, fmt = function(x) format(round(x, 2), nsmall = 2)),
+    mrow("Recapture rate", A$cs$recap_rate, B$cs$recap_rate, fmt = function(x) paste0(round(x, 1), "%")),
+    mrow("Trap-nights (effort)", A$cs$trap_nights, B$cs$trap_nights))
+  for (i in seq_along(rows)) {
+    r <- rows[[i]]
+    if (i %% 2 == 0)
+      grid.rect(x = unit(0, "npc"), y = gy(y), width = unit(1, "npc"), height = unit(0.22, "in"),
+                just = c("left", "top"), gp = gpar(fill = PG$zebra, col = NA))
+    grid.text(ascii(r$lab), x = unit(0, "npc"), y = gy(y + 0.02), just = c("left", "top"), gp = gpar(fontsize = 9.5))
+    grid.text(ascii(r$sa), x = unit(cax, "npc"), y = gy(y + 0.02), just = c("left", "top"),
+              gp = gpar(fontsize = 9.5, fontface = r$fa, col = if (r$fa == 2) PG$navy else PG$ink))
+    grid.text(ascii(r$sb), x = unit(cbx, "npc"), y = gy(y + 0.02), just = c("left", "top"),
+              gp = gpar(fontsize = 9.5, fontface = r$fb, col = if (r$fb == 2) PG$navy else PG$ink))
+    y <- y + 0.24
+  }
+  y <- y + 0.05
+  grid.text("Higher value per row in bold navy. Diversity is Hill numbers over distinct individuals.",
+            x = unit(0, "npc"), y = gy(y), just = c("left", "top"), gp = gpar(fontsize = 8, col = PG$muted))
+  y <- y + 0.34
+
+  shared <- intersect(A$all_sp, B$all_sp); onlyA <- setdiff(A$all_sp, B$all_sp); onlyB <- setdiff(B$all_sp, A$all_sp)
+  y <- draw_h4("Species overlap", y)
+  y <- draw_para(sprintf("%d species shared - %d only at %s - %d only at %s.",
+                         length(shared), length(onlyA), codeA, length(onlyB), codeB), y, 9.5)
+  y <- y + 0.12
+
+  y <- draw_h4("Top species (by individuals)", y)
+  grid.text(ascii(codeA), x = unit(0, "npc"), y = gy(y), just = c("left", "top"), gp = gpar(fontsize = 9.5, fontface = "bold", col = PG$navy))
+  grid.text(ascii(codeB), x = unit(0.5, "npc"), y = gy(y), just = c("left", "top"), gp = gpar(fontsize = 9.5, fontface = "bold", col = PG$navy))
+  y <- y + 0.24
+  splist <- function(p, x0) {
+    yy <- y
+    for (i in seq_len(nrow(p$sp))) {
+      grid.text(ascii(sprintf("%s  (%s ind)", p$sp$scientificName[i], format(p$sp$individuals[i], big.mark = ","))),
+                x = unit(x0, "npc"), y = gy(yy), just = c("left", "top"), gp = gpar(fontsize = 9, fontface = 3))
+      yy <- yy + 0.2
+    }
+    yy
+  }
+  y <- max(splist(A, 0.0), splist(B, 0.5)) + 0.1
+  popViewport()
+
+  if (has_gg) {
+    new_page(2, sprintf("%s vs %s", codeA, codeB)); yy <- 0.5
+    yy <- draw_h4(sprintf("Species composition - %s", codeA), yy)
+    yy <- embed_chart(chart_species(dA, A$cs), yy, 3.2)
+    yy <- draw_h4(sprintf("Species composition - %s", codeB), yy)
+    embed_chart(chart_species(dB, B$cs), yy, 3.2)
+    popViewport()
+  }
+  invisible(file)
+}

--- a/manifest.json
+++ b/manifest.json
@@ -3254,13 +3254,13 @@
       "checksum": "5995f4d3021b60fa57c6a63bd1ce15c1"
     },
     "R/report_pdf.R": {
-      "checksum": "c56a3f565ebf018dc7ce32dd37778fbb"
+      "checksum": "fde40ed98168de709c24a1d19c29eabc"
     },
     "R/site_metadata.R": {
       "checksum": "dd998c7eb8763e4ae1f33c060ed8364a"
     },
     "server.R": {
-      "checksum": "b6cada303e6f328757de4a837f26a2ad"
+      "checksum": "c608ecb6dbc3943dbfc6cb8ca9fb5074"
     },
     "ui.R": {
       "checksum": "de97e73bbdc14f7dedb9f9968dd154b6"

--- a/server.R
+++ b/server.R
@@ -715,9 +715,24 @@ server <- function(input, output, session) {
                        selected = if ("HARV" %in% ch) "HARV" else unname(ch)[2], width = "100%")),
       actionButton("runCompare", tagList(bs_icon("bar-chart-steps"), " Compare these sites"),
                    class = "btn-primary w-100 cmp-run"),
-      spin(uiOutput("compareOut"), img = "rat1.gif")
+      spin(uiOutput("compareOut"), img = "rat1.gif"),
+      downloadButton("compareReport",
+        tagList(bs_icon("file-earmark-arrow-down"), " Download comparison report (PDF)"),
+        class = "btn-outline-dark w-100 cmp-dl")
     ))
   })
+
+  # side-by-side comparison report (PDF) for the two picked sites — reads the
+  # live cmpA/cmpB selection, so it works whether or not Compare was pressed.
+  output$compareReport <- downloadHandler(
+    filename = function() sprintf("NEON-compare_%s-vs-%s.pdf", input$cmpA %||% "A", input$cmpB %||% "B"),
+    content = function(file) {
+      a <- input$cmpA; b <- input$cmpB
+      validate(need(!is.null(a) && !is.null(b) && !identical(a, b), "Pick two different sites to compare."))
+      ba <- load_site_bundle(a); bb <- load_site_bundle(b)
+      validate(need(!is.null(ba) && !is.null(bb), "Both sites must be in the offline bundle."))
+      render_compare_pdf(file, clean_mam(ba), site_label(a), clean_mam(bb), site_label(b))
+    })
 
   # build a one-site metric pack from its bundle (memoized so swapping a site
   # back in is instant and a repeat compare never re-crunches the heavy sites)


### PR DESCRIPTION
The two-site comparison report you asked me to plan + build. A **"Download comparison report (PDF)"** button in the Compare-two-sites modal produces a side-by-side PDF for the two picked sites:
- **Winner-highlighted metric table** — captures, individuals, richness, Hill q1, evenness, recapture rate, trap-nights (higher value per row in bold navy).
- **Species overlap** — N shared / N only-at-A / N only-at-B.
- **Top species per site** (two columns).
- **Page 2** (with ggplot2): each site's species-composition chart.

New `render_compare_pdf()` in `report_pdf.R` (reuses the report-card grid helpers); `output$compareReport` reads the live `cmpA`/`cmpB` selection, so it works whether or not "Compare" was pressed.

## Verification
- ✅ Rendered JORN vs SCBI — winner-bold table, overlap line, species columns all correct (page-1 screenshot)
- ✅ Modal button present with a valid session href; fetching it returns a valid **66 KB `application/pdf`** (200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)