### PR TITLE
docs: correct all 'NEON reuses tag numbers' copy (it doesn't)

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -319,14 +319,6 @@ max_dist_moved <- function(tx, ty) {
   round(max(d) * 10, 1)
 }
 
-# Largest gap (days) between an individual's consecutive captures — feeds the
-# tag-reuse suspicion flag.
-max_gap_days <- function(dates) {
-  dates <- sort(dates[!is.na(dates)])
-  if (length(dates) < 2) return(NA_integer_)
-  as.integer(max(diff(dates)))
-}
-
 # ---------------------------------------------------------------------------
 # build_leaderboard(): one row per individual with every metric the UI ranks.
 # ---------------------------------------------------------------------------
@@ -428,8 +420,8 @@ leaderboard_by <- function(lb, category = c("captures", "weight", "career", "roa
     captures = "captures", weight = "max_weight", career = "career_days",
     roam = "roam_m", chonk = "chonk_pct")
   out <- lb[!is.na(lb[[key]]), ]
-  # for the "career" board, hide the obvious tag-reuse artifacts so the ranking
-  # is honest; everywhere else keep all rows
+  # for the "career" board, hide the few impossible histories (same-day two-plot
+  # or beyond-lifespan span) so the ranking is honest; everywhere else keep all rows
   if (category == "career") out <- out[!out$tag_suspect, ]
   ord <- if (category == "chonk")
     order(-out[[key]], -out$max_weight) else order(-out[[key]])
@@ -564,15 +556,13 @@ genus_of <- function(sci) sub("^([A-Za-z]+).*$", "\\1", sci)
 # Per-species "longest confirmed time alive" — a right-censored FLOOR, NOT a
 # lifespan. The longest age-at-last-capture (approx_age_years = conservative
 # age-at-first-capture + career span) among non-tag-suspect individuals with >=3
-# captures, where >=5 such individuals exist. It is DOUBLY bounded:
-#  - biased LOW (right-censored): animals still alive or that left the grid are
-#    uncounted, and absence != death (death vs permanent emigration are
-#    indistinguishable here);
-#  - ceiling-capped: the tag-reuse guard sets aside any career >550 d (~1.5 yr)
-#    as a probable recycled ear tag, so this floor cannot exceed ~1.7 yr no matter
-#    how long an animal really lived — which is exactly why the abundant species
-#    pin near that value. We therefore present it as "longest confirmed alive,"
-#    not a lifespan, and show the AnAge captive max for scale.
+# captures, where >=5 such individuals exist. Biased LOW: animals still alive or
+# that left the grid are uncounted, absence != death (death vs permanent
+# emigration are indistinguishable), the record only spans the years sampled, and
+# it's the single longest individual so more-trapped species reach higher floors.
+# NEON keeps a tag on one animal for life (no number reuse; unique within a site),
+# so a multi-year career is a REAL long-lived individual — we trust it and show
+# the AnAge captive max alongside for scale.
 # (Restricting to juvenile-first animals — verified — collapses this to ~0.4 yr:
 # young-first animals are caught repeatedly in one season then gone, while the
 # long-tracked individuals are ~96-100% adult-first. Their approx_age_years uses

--- a/R/report_pdf.R
+++ b/R/report_pdf.R
@@ -341,7 +341,7 @@ render_report_pdf <- function(file, d, label, is_demo = FALSE, cc = NULL) {
                                paste0(fmt_int(cr$career_days), " d")))) }
     y <- draw_table(c("", "Species", "Value"), nrows, colx = c(0.00, 0.24, 0.66),
                     yTop = y, faces = c(2, 3, 1), repeat_header = function() { new_page(3, label, TRUE); 0.5 })
-    y <- draw_para(paste("Career length excludes likely reused ear-tags (career > 550 d or a > 300 d gap)."),
+    y <- draw_para(paste("Career length excludes only records that can't be one animal (same tag at two plots in a day, or a span beyond any wild lifespan); genuine multi-year careers are kept."),
                    y, 8, PG$muted)
   }
   if (has_gg) {

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ chart, and tap-any-statistic ranked breakdowns.
 | Metric | Definition |
 | --- | --- |
 | Captures | Times an individual (ear-tag ID) was handled in the window. |
-| Career span | Days between an individual's first and last capture (flagged when it exceeds plausible lifespan — a likely reused tag). |
+| Career span | Days between an individual's first and last capture. These desert rodents genuinely live 1–3.5 yr, so long careers are kept as real; only a history that can't be one animal (the same tag at two plots on a single day, or a span beyond any wild lifespan) is flagged `verify tag`. |
 | Roam radius / Max move | Mean displacement from, and maximum distance between, capture locations (traps are 10 m apart). A grid-bounded dispersion index, not a true home-range area. |
 | Chonk Index | Adult weight percentile within species. NEON rarely records body length and hind-foot barely scales with mass in these taxa, so a Scaled Mass Index would mostly rank noise — the body-size map shows the real relationship where it exists. |
 | MNKA / CPUE | Minimum Number Known Alive (Krebs 1966) and captures per 100 trap-nights — transparent abundance indices. |
@@ -103,7 +103,9 @@ chart, and tap-any-statistic ranked breakdowns.
 Methods reviewed against Peig & Green (2009), Krebs (1966), Gotelli & Colwell (2001), Chao (1987),
 Chao & Chiu (2016), and Otis et al. (1978). Chao1 is a lower-bound estimator, not a prediction of true
 richness; genus-only and ambiguous identifications are excluded from richness and diversity. NEON
-ear-tag numbers can be reused across years (the obvious cases are flagged), and an empty trap means
+keeps a tag on one animal for life and does not recycle tag numbers (a number is unique within a
+site), so a multi-year career is a real long-lived individual — we flag only the rare impossible
+history (e.g. the same tag at two plots on a single day), not long careers. An empty trap means
 "not detected," not "absent."
 
 ![About and methods](assets/about.png)

--- a/docs/index.html
+++ b/docs/index.html
@@ -262,8 +262,10 @@
             Chao1 estimate and its confidence interval.</li>
           <li><b>Body condition</b> — an adult weight percentile within species, rather than a
             scaled-mass index that would largely reflect measurement noise in these taxa.</li>
-          <li><b>Reused ear-tags</b> are flagged, and rarity tiers reflect trappability and
-            residency rather than ecological rarity.</li>
+          <li><b>Individual identity</b> — NEON keeps a tag on one animal for life and doesn't
+            reuse numbers, so multi-year careers are treated as the real long-lived animals they
+            are; only the rare impossible history (e.g. one tag at two plots on a single day) is
+            flagged. Rarity tiers reflect trappability and residency rather than ecological rarity.</li>
         </ul>
       </div>
     </div>

--- a/manifest.json
+++ b/manifest.json
@@ -3251,16 +3251,16 @@
       "checksum": "162d6bde4c29749d2211ec8370b07f14"
     },
     "R/helpers.R": {
-      "checksum": "60ea4d05a95e48e379728af5bc2983bc"
+      "checksum": "edd0296275fb14a9517cca1815f4ab99"
     },
     "R/report_pdf.R": {
-      "checksum": "5779ddada0c41621862c3a75e279808b"
+      "checksum": "74592c970ab4ad000171527af9750530"
     },
     "R/site_metadata.R": {
       "checksum": "dd998c7eb8763e4ae1f33c060ed8364a"
     },
     "server.R": {
-      "checksum": "6f12ae21ce1e2b04e64a42e6405be5cd"
+      "checksum": "2571c8e4c30946ca22166044a9de8a3d"
     },
     "ui.R": {
       "checksum": "d6c6793a9e71008fec26e0ba5b7aafc3"

--- a/server.R
+++ b/server.R
@@ -1148,9 +1148,9 @@ server <- function(input, output, session) {
 
     # approximate-age tile — a plain string (it carries a ~ / ≥ glyph the count-up
     # animator can't render). "~X.X yr" only for animals first caught young;
-    # "≥X.X yr" (left-censored minimum) for adult/unknown-first. Suppressed for
-    # tag-reuse suspects: a recycled-tag "career" is two animals, so any age is
-    # fiction — the existing "verify tag" chip already explains why.
+    # "≥X.X yr" (left-censored minimum) for adult/unknown-first. Suppressed when
+    # tag_suspect: an impossible history (same-day two-plot, or a beyond-lifespan
+    # span) isn't one animal, so any age is fiction — the "verify tag" chip says why.
     age_val <- row$approx_age_years[1]
     age_tile <- if (!isTRUE(row$tag_suspect[1]) && length(age_val) == 1 && !is.na(age_val) && is.finite(age_val)) {
       pre <- if (isTRUE(row$age_is_minimum[1])) "≥" else "~"
@@ -1591,7 +1591,7 @@ server <- function(input, output, session) {
       return(insight_banner("geo-fill", tone = "navy",
         "No between-grid recaptures: every tagged animal stayed on its home grid (high site fidelity)."))
     insight_banner("share-fill", tone = "navy",
-      HTML(sprintf("<span class='ci-hero'>%d</span> of %d tagged individuals were recaptured across <b>2+ grids</b>. Toggle <b>recapture movement</b> (top-right) to see the links — curved lines connect successive capture plots, <i>not</i> tracked routes, and a link across a long time gap can reflect a reused ear tag.",
+      HTML(sprintf("<span class='ci-hero'>%d</span> of %d tagged individuals were recaptured across <b>2+ grids</b>. Toggle <b>recapture movement</b> (top-right) to see the links — curved lines connect successive capture plots, <i>not</i> tracked routes, and a long gap between the two just means the animal went undetected in between.",
         rf$n_movers, rf$n_tagged)))
   })
 
@@ -2269,7 +2269,7 @@ server <- function(input, output, session) {
       div(class = "about-card",
         h4(bs_icon("clipboard-data"), " Metrics"),
         tags$ul(
-          tags$li(tags$b("Career span"), " — days between first and last capture. Spans > 520 d or with a > 200 d gap are flagged ", tags$b("verify tag"), " (likely a reused ear tag = two animals)."),
+          tags$li(tags$b("Career span"), " — days between first and last capture (these desert rodents genuinely live 1–3.5 yr, so long careers are real). Only a history that can't be one animal — the same tag at two plots on a single day, or a span beyond any wild lifespan — is flagged ", tags$b("verify tag"), "."),
           tags$li(tags$b("Roam radius"), " — mean displacement of captures from the trap-grid centroid (a grid-bounded dispersion index, not a true home-range area)."),
           tags$li(tags$b("Max move"), " — the largest distance between any two captures (MDM)."),
           tags$li(tags$b("MNKA"), " — Minimum Number Known Alive (Krebs 1966): a transparent abundance ", tags$em("index"), ", shown with captures / 100 trap-nights (CPUE)."),
@@ -2283,10 +2283,10 @@ server <- function(input, output, session) {
       div(class = "about-card",
         h4(bs_icon("share-fill"), " Between-grid movement"),
         p("The Plot map can overlay ", tags$b("recapture connectivity"), " — curved arcs linking trapping grids where the same tagged animals were recaptured, thicker where more individuals made that move. It shows site fidelity vs. inter-grid movement that the per-grid dots can't."),
-        p(class = "caveat", bs_icon("exclamation-triangle"), " Mark-recapture, ", tags$b("not"), " telemetry: an arc means \"caught here, then there,\" not a tracked route, and a link across a long gap can reflect a reused tag.")),
+        p(class = "caveat", bs_icon("exclamation-triangle"), " Mark-recapture, ", tags$b("not"), " telemetry: an arc means \"caught here, then there,\" not a tracked route — and a long gap between the two captures just means the animal went undetected in between.")),
       div(class = "about-card",
         h4(bs_icon("exclamation-diamond"), " Caveats"),
-        p("NEON ear-tag numbers can be reused across years (we flag the obvious cases). A trap that caught nothing means \"not detected,\" not \"absent.\" This is a data-exploration toy, not an authoritative population analysis — but the metrics are built to be defensible."),
+        p("NEON keeps a tag on one animal for life and doesn't recycle tag numbers (a number is unique within a site), so a multi-year capture career is a real long-lived individual, not a tag mix-up — we flag only the rare history that can't be one animal (e.g. the same tag at two plots on a single day). A trap that caught nothing means \"not detected,\" not \"absent.\" This is a data-exploration toy, not an authoritative population analysis — but the metrics are built to be defensible."),
         p("Reviewed for scientific soundness with input from a wildlife-monitoring methods audit (Peig & Green 2009; Krebs 1966; Gotelli & Colwell 2001; NEON DP1.10072.001 User Guide)."),
         p(bs_icon("envelope"), " ", tags$a(href = "mailto:tsgilbert@arizona.edu", "tsgilbert@arizona.edu"),
           " · ", tags$a(href = "https://data.neonscience.org/data-products/DP1.10072.001",


### PR DESCRIPTION
## Why
You spotted that the app (and the cover page) still said NEON reuses tagIDs — which the tag-identity fix ([#51](https://github.com/tgilbert14/NEON-Small-Mammal-Tracker-App/pull/51)) just established is **false**. NEON keeps a tag on one animal for life and doesn't recycle numbers; a number is unique within a site. This sweeps every stale statement.

## Fixed
- **Cover page** (`docs/index.html`) — the "Reused ear-tags are flagged" bullet, rewritten to: NEON doesn't reuse numbers, long careers are real long-lived animals, only the rare impossible history (one tag at two plots in a day) is flagged.
- **About page** (server.R) — the Career-span metric, the between-grid caveat, and the Caveats card no longer claim tags are reused or that a long gap implies reuse.
- **Recapture-map hero** — dropped "a link across a long time gap can reflect a reused ear tag"; a gap now correctly means "undetected in between."
- **README** — career-span row + methods caveat corrected.
- **PDF report** — career-leaderboard footnote corrected (no more "career > 550 d / > 300 d gap").
- **helpers.R** — fixed the stale `min_known_lifespan` comment (removed the obsolete ~1.7 yr tag-reuse-ceiling text), updated leaderboard/age comments, and removed the now-unused `max_gap_days()` helper (dead code after the rule change).

## Scope
Wording + dead-code removal only — no behavior change. Parse-checked; manifest LF-checksums updated for the three deployed files. Verified no remaining "reused tag" claims anywhere except the code comment that correctly says NEON does *not* reuse them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)