### PR TITLE
feat: QC inspectors (movers + outliers), env-picker relocation, species measurements in PDF, rebuild→republish docs

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -657,6 +657,7 @@ recapture_edges <- function(d) {
     }
   }
   base <- list(edges = NULL, n_movers = length(unique(movers)),
+               movers = unique(movers),
                n_tagged = n_tagged, n_plots = n_plots, max_pair_m = span, cen = cen)
   if (!length(rows)) return(base)
   pr <- do.call(rbind, rows)
@@ -667,6 +668,50 @@ recapture_edges <- function(d) {
     lat0 = ca$lat, lng0 = ca$lng, lat1 = cb$lat, lng1 = cb$lng,
     n_movers = agg$n_movers, stringsAsFactors = FALSE)
   base
+}
+
+# Capture-level detail for a set of individuals — feeds the QC "inspect" modals.
+# Ordered by tag then date, with the per-capture fields a user needs to judge
+# whether a tag is one animal or a mix-up: date, plot, species, sex, life stage.
+inspect_captures <- function(d, tags) {
+  if (is.null(d) || !length(tags)) return(NULL)
+  # same population recapture_edges() used to flag movers (needs a plot + coords),
+  # so the modal's plot count / same-day check can't disagree with the map.
+  h <- dplyr::filter(d, .data$tagID %in% tags, !is.na(.data$date), !is.na(.data$plotID),
+                     !is.na(.data$decimalLatitude), !is.na(.data$decimalLongitude))
+  if (!nrow(h)) return(NULL)
+  h %>% dplyr::arrange(.data$tagID, .data$date) %>%
+    dplyr::transmute(short = short_tag(.data$tagID),
+                     date = .data$date, plotID = .data$plotID,
+                     scientificName = .data$scientificName,
+                     sex = .data$sex, lifeStage = .data$lifeStage)
+}
+
+# The actual captures whose body measurement was flagged as a possible error
+# (beyond median +/- 5*MAD among this species' adults — same rule as
+# species_measurements()), so the QC modal can list the exact records to verify.
+# Returns a data frame (short, date, plot, value, sex) or NULL.
+flagged_measure_captures <- function(d, sp, measure) {
+  col <- switch(measure, weight = "weight", hindfoot = "hindfootLength",
+                tail = "tailLength", ear = "earLength", NULL)
+  if (is.null(col) || is.null(d)) return(NULL)
+  # species_level_only() so this draws from the exact same adult pool as
+  # species_measurements()'s nflag() — the flag rule must agree or the count
+  # here won't match the ⚠ tooltip's count.
+  h <- species_level_only(dplyr::filter(d, !is.na(.data$tagID), .data$scientificName == sp,
+                          .data$lifeStage %in% "adult"))
+  if (is.null(h) || !nrow(h)) return(NULL)
+  v <- h[[col]]; keep <- is.finite(v) & v > 0
+  h <- h[keep, , drop = FALSE]; v <- v[keep]
+  if (length(v) < 3) return(NULL)
+  m <- stats::median(v); s <- max(stats::mad(v), 0.1 * m)
+  if (!is.finite(s) || s <= 0) return(NULL)
+  flag <- abs(v - m) > 5 * s
+  if (!any(flag)) return(NULL)
+  data.frame(short = short_tag(h$tagID[flag]),
+             date = h$date[flag], plotID = h$plotID[flag],
+             value = round(v[flag], 1), sex = h$sex[flag],
+             median = m, stringsAsFactors = FALSE)
 }
 
 # Quadratic-Bezier arc points between two lon/lat endpoints (a curved connector,

--- a/R/report_pdf.R
+++ b/R/report_pdf.R
@@ -307,6 +307,29 @@ render_report_pdf <- function(file, d, label, is_demo = FALSE, cc = NULL) {
                   colx = c(0.00, 0.66, 0.78, 0.90), yTop = y, faces = c(3, 1, 1, 1), repeat_header = rh_fn)
   more_n <- nrow(sp) - nrow(sp_show)
   if (more_n > 0) y <- draw_para(sprintf("+ %d more taxa recorded", more_n), y, 9, PG$muted, 3)
+
+  # Body-measurement profile (adults only). Weight + hindfoot are measured at
+  # nearly every handling; tail/ear are too sparse for a clean table, so they're
+  # left to the on-screen profile. Ranges are the robust 5th-95th percentile.
+  mm <- tryCatch(species_measurements(d), error = function(e) NULL)
+  if (!is.null(mm) && nrow(mm) > 0) {
+    y <- draw_h4("Body measurements (adults)", y)
+    mm_show <- utils::head(mm, 12)
+    mcell <- function(med, lo, hi, n) if (is.na(med) || n < 3) "-" else
+      sprintf("%s [%s-%s]  n=%s", med, lo, hi, format(n, big.mark = ","))
+    mrows <- lapply(seq_len(nrow(mm_show)), function(i) {
+      r <- mm_show[i, ]
+      c(r$scientificName, mcell(r$w_med, r$w_lo, r$w_hi, r$w_n),
+        mcell(r$hf_med, r$hf_lo, r$hf_hi, r$hf_n))
+    })
+    rh_m <- function() { new_page(2, label); 0.5 }
+    y <- draw_table(c("Species", "Weight (g)", "Hindfoot (mm)"), mrows,
+                    colx = c(0.00, 0.40, 0.72), yTop = y, faces = c(3, 1, 1), repeat_header = rh_m)
+    y <- draw_para(paste("Adults only; median with the [5th-95th-percentile] range (a typical-adult envelope;",
+      "extreme values that look like data-entry errors are excluded from it). Tail & ear lengths are sparse",
+      "and shown in the app's Community profile."), y, 8, PG$muted)
+  }
+
   y <- draw_h4("Population structure", y)
   y <- draw_para(sprintf("Sex ratio: %s (%s F, %s M of %s handled). Life stage: %s.",
     sex_ratio, fmt_int(cs$n_female), fmt_int(cs$n_male), fmt_int(n_handled), stage_txt), y, 9.5)

--- a/docs/data-bundling-pattern.md
+++ b/docs/data-bundling-pattern.md
@@ -114,6 +114,23 @@ The deploy bundles the `.rds` files alongside the code (here `scripts/deploy.R` 
 the code and reproducible. Keep raw downloads out of the bundle (`.gitignore` the neon cache /
 `filesToProcess`) — only the trimmed `.rds` ship.
 
+### ⚠ Rebuilt bundles do NOT go live until you republish
+
+On a git-backed host (Posit Connect Cloud), the running app serves the **published snapshot**, and
+`manifest.json` pins a **SHA/MD5 checksum per bundled file**. So rebuilding a `.rds` locally changes
+nothing in production, and a changed bundle whose checksum wasn't refreshed can even fail the deploy.
+This bit us once — bundles looked updated locally but the live app kept serving the old data until a
+republish. The required sequence after any data rebuild:
+
+1. rebuild the bundles (`scripts/refresh_data.R`)
+2. **regenerate the manifest** so its checksums match the new files (`scripts/write_manifest.R` →
+   `rsconnect::writeManifest()`)
+3. `git add data/ manifest.json && git commit`
+4. **push + republish** on Connect Cloud (git-backed redeploy)
+
+Miss step 2 or 4 and the deployed app silently keeps the stale data. (On a non-manifest host like
+shinyapps.io, there's no checksum step, but you still must redeploy — the bundle only updates on push.)
+
 ---
 
 ## When to reach for this
@@ -134,4 +151,5 @@ the code and reproducible. Keep raw downloads out of the bundle (`.gitignore` th
    into `data/<thing>/<id>.rds`. Make it **resumable** + **tryCatch per item**.
 2. App: `load_bundle(id)` reads the file; **filter in memory**; **fall back** to live if missing.
 3. Commit the `.rds` files (they're the durable store) and include them in the deploy bundle.
-4. To refresh: delete the stale files, re-run the script, redeploy (or schedule it).
+4. To refresh: delete the stale files, re-run the script, **regenerate the manifest, commit, and
+   republish** — on a git-backed/manifest host the live app keeps the old data until you do.

--- a/manifest.json
+++ b/manifest.json
@@ -3251,19 +3251,19 @@
       "checksum": "162d6bde4c29749d2211ec8370b07f14"
     },
     "R/helpers.R": {
-      "checksum": "edd0296275fb14a9517cca1815f4ab99"
+      "checksum": "74313bcb30a249850a3dca4ee40bf25f"
     },
     "R/report_pdf.R": {
-      "checksum": "74592c970ab4ad000171527af9750530"
+      "checksum": "b38dfd1642658ccd59b1de91c77872be"
     },
     "R/site_metadata.R": {
       "checksum": "dd998c7eb8763e4ae1f33c060ed8364a"
     },
     "server.R": {
-      "checksum": "2571c8e4c30946ca22166044a9de8a3d"
+      "checksum": "61bbadfb89acb2f8dbdc1cf6550c82f8"
     },
     "ui.R": {
-      "checksum": "d6c6793a9e71008fec26e0ba5b7aafc3"
+      "checksum": "a8898806276070cb22dc913d4b5c945a"
     },
     "www/app.js": {
       "checksum": "27b51557f767db76b5b387aff1f0efe3"
@@ -3284,7 +3284,7 @@
       "checksum": "03caa0fdc9353ecf3495715d7e5f11f5"
     },
     "www/styles.css": {
-      "checksum": "33935df5e50fa71c5b1fd35597c0d1c3"
+      "checksum": "706246616a43a0b993ce16f16c8e4bfe"
     }
   },
   "users": null

--- a/scripts/refresh_data.R
+++ b/scripts/refresh_data.R
@@ -7,8 +7,19 @@
 # all ~47 fit in the app bundle and load instantly — no live download for users.
 #
 # RESUMABLE: skips sites whose .rds already exists. Delete a file to re-pull it.
-# To refresh with newer data: delete data/sites/*.rds (or the ones you want) and
-# re-run, then redeploy.
+#
+# !! AFTER REBUILDING BUNDLES YOU MUST REPUBLISH !! The deployed app keeps serving
+# the OLD data until you do. Posit Connect Cloud serves the *published* git
+# snapshot, and manifest.json pins a CHECKSUM per bundled file — so a changed .rds
+# whose checksum wasn't refreshed will not take effect (and can fail the deploy).
+# Full refresh sequence, in order:
+#   1. delete data/sites/*.rds (or just the sites to refresh) and re-run THIS script
+#   2. Rscript scripts/write_manifest.R        # regenerate manifest.json checksums
+#   3. git add data/ manifest.json && git commit
+#   4. push, then republish on Connect Cloud (git-backed redeploy)
+# The live app shows the new data only once step 4 finishes — a local rebuild
+# alone changes nothing in production. (This bit us once: bundles looked updated
+# locally but the deployed app didn't change until a republish.)
 #
 # Run from the project root:
 #   Rscript scripts/refresh_data.R

--- a/server.R
+++ b/server.R
@@ -1591,8 +1591,46 @@ server <- function(input, output, session) {
       return(insight_banner("geo-fill", tone = "navy",
         "No between-grid recaptures: every tagged animal stayed on its home grid (high site fidelity)."))
     insight_banner("share-fill", tone = "navy",
-      HTML(sprintf("<span class='ci-hero'>%d</span> of %d tagged individuals were recaptured across <b>2+ grids</b>. Toggle <b>recapture movement</b> (top-right) to see the links — curved lines connect successive capture plots, <i>not</i> tracked routes, and a long gap between the two just means the animal went undetected in between.",
-        rf$n_movers, rf$n_tagged)))
+      HTML(sprintf("<span class='ci-hero'>%d</span> of %d tagged individuals were recaptured across <b>2+ grids</b>. Toggle <b>recapture movement</b> (top-right) to see the links — curved lines connect successive capture plots, <i>not</i> tracked routes, and a long gap between the two just means the animal went undetected in between. <a href='#' class='inspect-link' onclick=\"Shiny.setInputValue('showMovers', Math.random(), {priority:'event'}); return false;\">Inspect these %d &raquo;</a>",
+        rf$n_movers, rf$n_tagged, rf$n_movers)))
+  })
+
+  # QC inspector — list each cross-grid mover's capture history so a user can
+  # judge "one real mover" vs "two animals sharing a tag" (a sex/species change
+  # across captures, or a same-day two-plot record, is the tell).
+  observeEvent(input$showMovers, {
+    d <- rv$data; rf <- recap_flow(); req(d, !is.null(rf))
+    cap <- inspect_captures(d, rf$movers)
+    if (is.null(cap) || !nrow(cap)) {
+      showNotification("No cross-grid movers to inspect here.", type = "message"); return()
+    }
+    blocks <- lapply(split(cap, factor(cap$short, levels = unique(cap$short))), function(g) {
+      sexes <- unique(g$sex[g$sex %in% c("M", "F")])
+      spp   <- unique(g$scientificName[!is.na(g$scientificName)])
+      sameday <- any(tapply(g$plotID, g$date, function(p) length(unique(p))) > 1, na.rm = TRUE)
+      tells <- c(if (length(sexes) > 1) "sex changes", if (length(spp) > 1) "species changes",
+                 if (isTRUE(sameday)) "same day at 2 plots — physically impossible")
+      div(class = "mover-block",
+        div(class = "mover-head", tags$b(g$short[1]), " · ", em(spp[1]),
+          tags$span(class = "mover-n", sprintf(" %d captures, %d plots", nrow(g), dplyr::n_distinct(g$plotID))),
+          if (length(tells))
+            tags$span(class = "mover-warn", bs_icon("exclamation-triangle-fill"),
+                      paste0(" ", paste(tells, collapse = "; "), " → likely two animals"))),
+        tags$table(class = "inspect-tbl",
+          tags$thead(tags$tr(lapply(c("Date", "Plot", "Species", "Sex", "Stage"), tags$th))),
+          tags$tbody(lapply(seq_len(nrow(g)), function(i)
+            tags$tr(
+              tags$td(format(g$date[i], "%Y-%m-%d")), tags$td(g$plotID[i]),
+              tags$td(em(g$scientificName[i])),
+              tags$td(ifelse(is.na(g$sex[i]), "?", g$sex[i])),
+              tags$td(ifelse(is.na(g$lifeStage[i]), "?", g$lifeStage[i])))))))
+    })
+    showModal(modalDialog(
+      title = tagList(bs_icon("share-fill"), " Individuals caught at 2+ grids"),
+      size = "l", easyClose = TRUE, footer = modalButton("Close"),
+      p(class = "inspect-note", HTML("NEON keeps a tag on one animal for life and doesn't reuse numbers, so most of these are <b>real</b> long-distance movers. But a tag whose <b>sex</b> or <b>species</b> changes across captures, or that shows up at two plots on the <b>same day</b>, is more likely two animals sharing a number — those are flagged below for you to verify against the field records.")),
+      div(class = "movers-wrap", blocks)
+    ))
   })
 
   # teal AGGREGATE layer — redraws only when the toggle or base map changes
@@ -1889,10 +1927,10 @@ server <- function(input, output, session) {
     # measure contains values flagged as possible data-entry errors (beyond
     # median±5·MAD). The flagged value is KEPT — its raw min–max rides in the
     # tooltip for field QC — but it's excluded from the median and the p5–p95 range.
-    cell <- function(med, lo, hi, n, nflag, rmin, rmax, unit, min_n = 3) {
+    cell <- function(med, lo, hi, n, nflag, rmin, rmax, unit, sp, meas, min_n = 3) {
       warn <- ifelse(!is.na(nflag) & nflag > 0,
-        sprintf(" <span class='mz-flag' title='%s value(s) here are beyond the plausible adult range (raw %s–%s %s) — kept for your QC, but excluded from the median and the 5th–95th-percentile range shown'>&#9888;</span>",
-                format(nflag, big.mark = ","), rmin, rmax, unit),
+        sprintf(" <span class='mz-flag' style='cursor:pointer' onclick=\"Shiny.setInputValue('showOutliers','%s||%s||'+Math.random(),{priority:'event'})\" title='%s value(s) beyond the plausible adult range (raw %s–%s %s) — click to inspect &amp; verify. Kept in the data but excluded from the median and the 5th–95th-percentile range.'>&#9888;</span>",
+                sp, meas, format(nflag, big.mark = ","), rmin, rmax, unit),
         "")
       ifelse(is.na(med) | n < min_n, "<span class='muted'>—</span>",
         sprintf("<b>%s</b> <span class='mz-rng'>[%s–%s]</span> <span class='mz-n'>n=%s</span>%s",
@@ -1901,15 +1939,42 @@ server <- function(input, output, session) {
     df <- tibble::tibble(
       Species = sprintf("<span class='ind-cell'><span class='ind-emoji'>%s</span><span class='ind-id'><i>%s</i></span></span>", m$emoji, m$scientificName),
       Indiv = m$n_ind,
-      `Weight (g)`    = cell(m$w_med,  m$w_lo,  m$w_hi,  m$w_n,  m$w_nflag,  m$w_min,  m$w_max,  "g"),
-      `Hindfoot (mm)` = cell(m$hf_med, m$hf_lo, m$hf_hi, m$hf_n, m$hf_nflag, m$hf_min, m$hf_max, "mm"),
-      `Tail (mm)`     = cell(m$tl_med, m$tl_lo, m$tl_hi, m$tl_n, m$tl_nflag, m$tl_min, m$tl_max, "mm"),
-      `Ear (mm)`      = cell(m$el_med, m$el_lo, m$el_hi, m$el_n, m$el_nflag, m$el_min, m$el_max, "mm"))
+      `Weight (g)`    = cell(m$w_med,  m$w_lo,  m$w_hi,  m$w_n,  m$w_nflag,  m$w_min,  m$w_max,  "g",  m$scientificName, "weight"),
+      `Hindfoot (mm)` = cell(m$hf_med, m$hf_lo, m$hf_hi, m$hf_n, m$hf_nflag, m$hf_min, m$hf_max, "mm", m$scientificName, "hindfoot"),
+      `Tail (mm)`     = cell(m$tl_med, m$tl_lo, m$tl_hi, m$tl_n, m$tl_nflag, m$tl_min, m$tl_max, "mm", m$scientificName, "tail"),
+      `Ear (mm)`      = cell(m$el_med, m$el_lo, m$el_hi, m$el_n, m$el_nflag, m$el_min, m$el_max, "mm", m$scientificName, "ear"))
     DT::datatable(df, escape = FALSE, rownames = FALSE, selection = "none",
       class = "compact stripe hover nowrap leader-dt",
       options = list(pageLength = 12, dom = "tip", scrollX = TRUE,
         columnDefs = list(list(className = "dt-center", targets = 1:5)),
         language = list(search = "", searchPlaceholder = "filter species…")))
+  })
+
+  # QC inspector — clicking a measurement's ⚠ lists the exact flagged captures so
+  # a field tech can verify the record (the value stays in the data either way).
+  observeEvent(input$showOutliers, {
+    d <- rv$data; req(d)
+    parts <- strsplit(input$showOutliers, "\\|\\|")[[1]]
+    if (length(parts) < 2) return()
+    sp <- parts[1]; measure <- parts[2]
+    fc <- flagged_measure_captures(d, sp, measure)
+    if (is.null(fc) || !nrow(fc)) { showNotification("No flagged values to inspect.", type = "message"); return() }
+    unit <- if (measure == "weight") "g" else "mm"
+    mlab <- c(weight = "weight", hindfoot = "hind-foot length",
+              tail = "tail length", ear = "ear length")[[measure]]
+    showModal(modalDialog(
+      title = tagList(bs_icon("exclamation-triangle-fill"), sprintf(" Possible %s errors — %s", mlab, sp)),
+      size = "m", easyClose = TRUE, footer = modalButton("Close"),
+      p(class = "inspect-note", HTML(sprintf("Adult %s median here is <b>%s %s</b>. The records below fall far outside the plausible adult range (beyond median ± 5×MAD) — most likely data-entry errors. They are <b>kept in the data</b> but excluded from the median and the 5th–95th-percentile range; verify them against the field sheets.",
+        mlab, round(fc$median[1], 1), unit))),
+      tags$table(class = "inspect-tbl",
+        tags$thead(tags$tr(lapply(c("Tag", "Date", "Plot", sprintf("Value (%s)", unit), "Sex"), tags$th))),
+        tags$tbody(lapply(seq_len(nrow(fc)), function(i)
+          tags$tr(
+            tags$td(fc$short[i]), tags$td(format(fc$date[i], "%Y-%m-%d")),
+            tags$td(fc$plotID[i]), tags$td(tags$b(fc$value[i])),
+            tags$td(ifelse(is.na(fc$sex[i]), "?", fc$sex[i]))))))
+    ))
   })
 
   # ---- minimum known lifespan (a right-censored FLOOR, not a lifespan) -----

--- a/ui.R
+++ b/ui.R
@@ -252,9 +252,25 @@ ui <- bslib::page_sidebar(
             h4("Defensible population signals"),
             p("Minimum Number Known Alive (MNKA) and catch-per-unit-effort are honest abundance indices; the accumulation curve shows whether trapping ran long enough to find every species."))
         ),
-        # "Compare with environment" lives HERE (moved off the sidebar) so it's
-        # discoverable right where its overlays appear. Hidden until the site has
-        # env data; choices + show/hide are driven server-side by id.
+        conditionalPanel("output.hasEnv == true",
+          card(full_screen = TRUE,
+            card_head("bar-chart-steps", "Which environmental driver does this population track best?",
+              info_pop("Driver comparison",
+                p("For every co-located driver, we scan lags 0–12 months and keep the ", tags$b("strongest correlation"), " with monthly catch-per-effort."),
+                p("Bars show that best correlation (sign = direction); the label is the lag at which it peaks. The longest bar is the signal this population follows most closely — the others are candidate co-drivers."),
+                p(tags$b("Reading the r-value:"), " r runs from -1 to +1 and measures how tightly two things move together — near the ends they rise and fall in near-lockstep, near 0 they barely relate. The ", tags$b("sign is the direction"), ": “+” means more driver → more animals, “−” means more driver → fewer."),
+                p("It is ", tags$b("not"), " the percentage of the population explained — that is ", tags$b("r²"), ", the square of r (so r = -0.50 means about a quarter, 0.25, of the month-to-month swings line up). With only a handful of months and many lags scanned, read r as a ", tags$b("lead worth a closer look"), " — not a proven cause."),
+                p(class = "pop-caveat", bs_icon("exclamation-triangle"),
+                  " A longer bar isn't proof of cause: drivers correlate with each other, and scanning many lags can flag a strong match by chance. Treat this as a ranking of leads to investigate."))),
+            uiOutput("envCorrNote"),
+            spin(plotlyOutput("envDriverRank", height = "300px")),
+            div(class = "env-pick-hint",
+              bs_icon("arrow-down-circle"),
+              " Pick a driver just below to overlay it on the ", tags$b("population trend"),
+              " and watch the abundance rise and fall with it."))),
+        # "Compare with environment" lives right above the abundance chart it
+        # overlays (moved off the sidebar, then down here next to its target).
+        # Hidden until the site has env data; choices + show/hide driven by id.
         hidden(div(id = "envPickerWrap", class = "env-pop-bar",
           div(class = "env-pop-row",
             div(class = "env-pop-sel",
@@ -280,18 +296,6 @@ ui <- bslib::page_sidebar(
               div(class = "env-lag-hint", "0 = same month · 3 = driver 3 months earlier"))),
           uiOutput("envSourceNote")
         )),
-        conditionalPanel("output.hasEnv == true",
-          card(full_screen = TRUE,
-            card_head("bar-chart-steps", "Which environmental driver does this population track best?",
-              info_pop("Driver comparison",
-                p("For every co-located driver, we scan lags 0–12 months and keep the ", tags$b("strongest correlation"), " with monthly catch-per-effort."),
-                p("Bars show that best correlation (sign = direction); the label is the lag at which it peaks. The longest bar is the signal this population follows most closely — the others are candidate co-drivers."),
-                p(tags$b("Reading the r-value:"), " r runs from -1 to +1 and measures how tightly two things move together — near the ends they rise and fall in near-lockstep, near 0 they barely relate. The ", tags$b("sign is the direction"), ": “+” means more driver → more animals, “−” means more driver → fewer."),
-                p("It is ", tags$b("not"), " the percentage of the population explained — that is ", tags$b("r²"), ", the square of r (so r = -0.50 means about a quarter, 0.25, of the month-to-month swings line up). With only a handful of months and many lags scanned, read r as a ", tags$b("lead worth a closer look"), " — not a proven cause."),
-                p(class = "pop-caveat", bs_icon("exclamation-triangle"),
-                  " A longer bar isn't proof of cause: drivers correlate with each other, and scanning many lags can flag a strong match by chance. Treat this as a ranking of leads to investigate."))),
-            uiOutput("envCorrNote"),
-            spin(plotlyOutput("envDriverRank", height = "300px")))),
         card(full_screen = TRUE,
           card_head("incognito", "Detection-corrected abundance",
             info_pop("Detection-corrected abundance", placement = "left",

--- a/www/styles.css
+++ b/www/styles.css
@@ -99,6 +99,10 @@ body {
 [data-bs-theme="dark"] .env-pop-bar { background: linear-gradient(180deg, #1b2942 0%, var(--paper) 100%); }
 @media (max-width: 560px) { .env-pop-row { gap: 6px; } }
 .env-lag-hint { font-size: 10.5px; color: var(--muted); line-height: 1.35; margin: -6px 0 4px; }
+/* pointer from the driver-ranking card down to the env picker + trend overlay */
+.env-pick-hint { font-size: 12.5px; color: var(--pine); font-weight: 600; text-align: center;
+  margin-top: 10px; padding-top: 9px; border-top: 1px dashed var(--line); }
+.env-pick-hint .bi { vertical-align: -2px; margin-right: 3px; }
 .env-source { display: flex; gap: 7px; align-items: flex-start; font-size: 11px; line-height: 1.4;
   border-radius: 8px; padding: 7px 9px; margin-top: 4px; }
 .env-source .bi { margin-top: 1px; flex: none; }
@@ -876,6 +880,25 @@ table.dataTable tbody tr:active { background: #dfe8f4 !important; }
 .lsp-val { font-weight: 800; font-size: 14px; }
 .lsp-n { font-size: 11px; color: var(--muted); }
 .lsp-cap { font-size: 11px; color: var(--muted); font-style: italic; }
+
+/* ---- QC inspector links + modals (cross-grid movers, measurement outliers) - */
+.inspect-link { color: var(--pine); font-weight: 700; white-space: nowrap; text-decoration: underline; cursor: pointer; }
+.inspect-link:hover { color: var(--cardinal, #9b2335); }
+.inspect-note { font-size: 13px; color: var(--muted); line-height: 1.5; margin-bottom: 14px; }
+.movers-wrap { display: flex; flex-direction: column; gap: 14px; }
+.mover-block { border: 1px solid var(--line); border-radius: 10px; overflow: hidden; }
+.mover-head { background: rgba(127,127,127,.06); padding: 7px 11px; font-size: 13px; border-bottom: 1px solid var(--line); }
+.mover-n { color: var(--muted); font-size: 12px; }
+.mover-warn { color: #9a6b12; font-weight: 700; margin-left: 6px; }
+.mover-warn .bi { vertical-align: -2px; }
+.inspect-tbl { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.inspect-tbl th { text-align: left; font-weight: 700; color: var(--muted); padding: 5px 11px; font-size: 11px; text-transform: uppercase; letter-spacing: .3px; }
+.inspect-tbl td { padding: 5px 11px; border-top: 1px solid var(--line); }
+.inspect-tbl tbody tr:hover { background: rgba(127,127,127,.05); }
+/* dark mode: pine text and the dark amber go low-contrast on dark paper — brighten */
+[data-bs-theme="dark"] .inspect-link { color: #b9d2f2; }
+[data-bs-theme="dark"] .env-pick-hint { color: #b9d2f2; }
+[data-bs-theme="dark"] .mover-warn { color: #e8c552; }
 
 /* ---- Hall of Fame podium (top-3, olympic: 2nd · 1st-raised · 3rd) ------ */
 .podium { display: flex; justify-content: center; align-items: flex-end; gap: 14px; margin: 4px 0 16px; }


### PR DESCRIPTION
Implements the small-mammal-app items from the batch request.

## 1. Env picker moved to where it acts
The "Compare with environment" picker + lag slider moved from the top of the Population tab to **right above the Detection-corrected abundance chart** it overlays, with a pointer note in the driver-ranking card ("Pick a driver just below to overlay it on the population trend…"). Pure reorder — input IDs unchanged.

## 2. Species measurements in the PDF report
Added an adults-only **body-measurement table** (Weight + Hindfoot, median [p5–p95] + n) to the report via `species_measurements()`. Tail/ear are too sparse for a clean PDF table, so they stay in the app's Community profile.

## 3. Cross-grid recapture inspector
The "*X* recaptured across 2+ grids" banner now has an **"Inspect these N »"** link → a modal listing each mover's capture history grouped by tag, and **flags** the ones whose **sex or species changes** across captures, or that appear at **two plots on the same day** ("likely two animals"). So a user can decide same-vs-different animal. (`recapture_edges()` now returns the mover IDs; new `inspect_captures()`.)

## 4. Measurement outlier inspector
Clicking a measurement's amber **⚠** in the Community table opens a modal listing the **exact flagged captures** (tag/date/plot/value) for QC. New `flagged_measure_captures()` uses the *same* median ± 5·MAD rule and the same `species_level_only` adult pool as the table's flag, so the counts agree.

## 5. Rebuild → republish docs
Documented that on Connect Cloud the live app keeps the **old** data until you **regenerate the manifest + republish** (the manifest pins a checksum per bundle) — in `refresh_data.R` and `data-bundling-pattern.md`.

## Verification
In-browser: env order correct (driver card → picker+note → abundance); PDF renders (77 KB); movers modal flags a real sex-change + same-day case; outlier modal lists D. merriami's 4 bad weights (8/9/357/12 g). Adversarial review (Quinn + Wes): **no blockers**; applied Quinn's two defensive fixes (`species_level_only` parity on the outlier helper; coordinate-filter alignment on the movers helper) and dark-mode contrast overrides. Manifest checksums updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)