### PR TITLE
Size Lab fast-follows: honest fit line, jittered dots, robust drag, bigger chip target

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3260,7 +3260,7 @@
       "checksum": "dd998c7eb8763e4ae1f33c060ed8364a"
     },
     "server.R": {
-      "checksum": "c7e2f0271873b6dceca0cefba017fe4f"
+      "checksum": "aab712dc6b01d173e2c1cf3e4d69b056"
     },
     "ui.R": {
       "checksum": "06c23dc1ff0e52075aa12b33ebf05c34"
@@ -3272,7 +3272,7 @@
       "checksum": "c05030299121b6bb32e2794f0decb120"
     },
     "www/pincards.js": {
-      "checksum": "f4a5175eb943f85af06a72ca50ce6489"
+      "checksum": "5c994c45e1a84d964ebb9dc22319fd3b"
     },
     "www/images/nyan-cat.gif": {
       "checksum": "7d5d665f92c09858439458678bc879a4"
@@ -3287,7 +3287,7 @@
       "checksum": "03caa0fdc9353ecf3495715d7e5f11f5"
     },
     "www/styles.css": {
-      "checksum": "55b42d834b509bae1b9688199e4af7f2"
+      "checksum": "45f1edea853f8df6e09930c2390d0a8c"
     }
   },
   "users": null

--- a/server.R
+++ b/server.R
@@ -1481,6 +1481,25 @@ server <- function(input, output, session) {
     full_pts <- pts                          # pre-downsample (single-species stats + diamond)
     if (nrow(pts) > 1500) { set.seed(7); pts <- pts[sort(sample.int(nrow(pts), 1500)), ] }
 
+    # S5: deterministic sub-pixel jitter so individuals that round to identical
+    # (hind-foot, weight) coords fan out and each stays individually tappable
+    # (hind-foot is whole-mm, so a busy species otherwise stacks into one un-pickable
+    # blob). Keyed on tagID -> stable across renders, no global-RNG touch; the hover
+    # and the pin card still report each animal's TRUE measured means.
+    .jit <- function(tags, amp, salt) {
+      if (!length(tags) || !is.finite(amp) || amp <= 0) return(rep(0, length(tags)))
+      h <- vapply(paste0(tags, salt), function(s) { z <- utf8ToInt(s); (sum(z * seq_along(z)) %% 997) / 997 }, numeric(1))
+      (h - 0.5) * 2 * amp
+    }
+    rng_x <- suppressWarnings(diff(range(pts$avg_hf, na.rm = TRUE)))
+    rng_y <- suppressWarnings(diff(range(pts$avg_weight, na.rm = TRUE)))
+    amp_x <- if (is.finite(rng_x) && rng_x > 0) rng_x * 0.012 else 0
+    amp_y <- if (is.finite(rng_y) && rng_y > 0) rng_y * 0.012 else 0
+    pts$jx <- pts$avg_hf + .jit(pts$tagID, amp_x, "x")
+    pts$jy <- pts$avg_weight + .jit(pts$tagID, amp_y, "y")
+    pts$hovtxt <- paste0(pts$short, " \U00B7 ", pts$scientificName, "<br>",
+                         round(pts$avg_hf, 1), " mm \U00B7 ", round(pts$avg_weight, 1), " g")
+
     # theme-aware greys so every mark stays legible on the dark navy background
     muted_col <- if (is_dark()) "#9fb0c4" else "#6b7a85"
     quad_col  <- if (is_dark()) "#7e8da0" else "#9aa6b2"
@@ -1493,12 +1512,12 @@ server <- function(input, output, session) {
     for (s in sort(unique(pts$scientificName))) {
       sub <- pts[pts$scientificName == s, ]
       col <- if (s %in% names(pal)) pal[[s]] else "#16386e"
-      p <- p %>% add_trace(data = sub, x = ~avg_hf, y = ~avg_weight,
+      p <- p %>% add_trace(data = sub, x = ~jx, y = ~jy,
         type = "scatter", mode = "markers", name = s, customdata = ~tip, showlegend = show_leg,
         marker = list(color = col, size = 9, opacity = 0.82,
                       line = list(color = "#ffffff", width = 0.6)),
-        text = ~paste0(short, " · ", scientificName),
-        hovertemplate = "%{text}<br>%{x} mm · %{y} g<extra></extra>")
+        text = ~hovtxt,                                  # carries the TRUE mm/g (markers are jittered)
+        hovertemplate = "%{text}<extra></extra>")
     }
 
     # Be explicit about the life-stage scope: the dot is a mean over an animal's
@@ -1545,16 +1564,26 @@ server <- function(input, output, session) {
       # adult-calibrated line over juvenile dots would read them as "underweight".
       # So draw it only with "Adults only" on, fit on those adult dots, label adult.
       if (isTRUE(input$scatterAdults)) {
-        ss <- species_scaling(d); srow <- ss[ss$scientificName == sp, ]
-        if (nrow(srow) == 1 && !is.na(srow$b) && nrow(full_pts) > 1) {
-          a  <- mean(log(full_pts$avg_weight)) - srow$b * mean(log(full_pts$avg_hf))
-          lx <- seq(min(full_pts$avg_hf), max(full_pts$avg_hf), length.out = 40)
-          p <- p %>% add_trace(x = lx, y = exp(a + srow$b * log(lx)), type = "scatter", mode = "lines",
-            name = sprintf("adult size–mass fit (r=%.2f)", srow$r), hoverinfo = "skip",
+        # S4: fit on the DOTS ACTUALLY SHOWN (per-individual adult means, respecting
+        # the plot filter) and label with THEIR r — so the line + r describe what's on
+        # screen, not a different (all-plots, per-capture) population. SMA (sd-ratio)
+        # slope on true coords, same gate as before (n>=15 & |r|>=0.3).
+        fp <- full_pts[is.finite(full_pts$avg_hf) & is.finite(full_pts$avg_weight) &
+                       full_pts$avg_hf > 0 & full_pts$avg_weight > 0, , drop = FALSE]
+        lw <- log(fp$avg_weight); lh <- log(fp$avg_hf)
+        rr <- if (nrow(fp) >= 15 && stats::sd(lh) > 0 && stats::sd(lw) > 0)
+                suppressWarnings(stats::cor(lh, lw)) else NA_real_
+        if (is.finite(rr) && abs(rr) >= 0.3) {
+          b <- stats::sd(lw) / stats::sd(lh) * sign(rr)
+          a <- mean(lw) - b * mean(lh)
+          lx <- seq(min(fp$avg_hf), max(fp$avg_hf), length.out = 40)
+          p <- p %>% add_trace(x = lx, y = exp(a + b * log(lx)), type = "scatter", mode = "lines",
+            name = sprintf("adult size–mass fit (r=%.2f)", rr), hoverinfo = "skip", inherit = FALSE,
             line = list(color = fit_col, width = 2, dash = "dash"))
         } else {
           ann[[length(ann) + 1L]] <- list(
-            text = "↳ hind-foot barely predicts mass in this species — read position, not a line",
+            text = if (nrow(fp) < 15) "↳ too few adults here to fit a size–mass line"
+                   else "↳ hind-foot barely predicts mass in these adults — read position, not a line",
             x = 0, y = 1.20, xref = "paper", yref = "paper", showarrow = FALSE, xanchor = "left",
             font = list(color = muted_col, size = 11))
         }
@@ -1573,11 +1602,15 @@ server <- function(input, output, session) {
     if (!is.null(tag)) {
       ir <- full_pts[full_pts$tagID == tag, ]
       if (nrow(ir) == 1)
-        p <- p %>% add_trace(x = ir$avg_hf, y = ir$avg_weight, type = "scatter", mode = "markers",
+        # jitter by the SAME per-tag amount as its species dot so the diamond sits
+        # on it (not beside it); hover still reports the true measured means.
+        p <- p %>% add_trace(x = ir$avg_hf + .jit(ir$tagID, amp_x, "x"),
+          y = ir$avg_weight + .jit(ir$tagID, amp_y, "y"), type = "scatter", mode = "markers",
           name = "★ tracking", showlegend = TRUE, customdata = ir$tip,
           marker = list(symbol = "diamond", size = 17, color = "#c9a300",
                         line = list(color = "#ffffff", width = 1.6)),
-          hovertemplate = paste0("tracking ", ir$short[1], "<br>%{x} mm · %{y} g<extra></extra>"))
+          hovertemplate = paste0("tracking ", ir$short[1], "<br>",
+            round(ir$avg_hf[1], 1), " mm · ", round(ir$avg_weight[1], 1), " g<extra></extra>"))
     }
 
     # the site/year caption, folded into the annotation list (not via ctx_anno's

--- a/www/pincards.js
+++ b/www/pincards.js
@@ -115,21 +115,36 @@
       ln.remove(); dot.remove(); pin.remove();
     });
 
-    /* drag-to-move (clamped so a fat-thumb drag can't fling the card off-box) */
+    /* drag-to-move (clamped so a fat-thumb drag can't fling the card off-box).
+       A 4px move threshold (S8): a near-miss TAP — e.g. a few px off the QC chip —
+       never engages the drag or preventDefaults, so the intended click still fires.
+       move/up/cancel bound on WINDOW + capture released (S7): a pointerup off the
+       card (scroll-steal, edge swipe, pointercancel) can never leave it stuck. */
     pin.addEventListener("pointerdown", function (ev) {
       if (ev.target.closest("a, .smt-pin-close, .smt-open, .smt-pin-resize")) return;
-      ev.preventDefault();
-      try { pin.setPointerCapture(ev.pointerId); } catch (e) {}
       var sx = ev.clientX - pin.offsetLeft, sy = ev.clientY - pin.offsetTop;
+      var startX = ev.clientX, startY = ev.clientY, dragging = false;
       function mv(em) {
+        if (!dragging) {
+          if (Math.abs(em.clientX - startX) < 4 && Math.abs(em.clientY - startY) < 4) return;
+          dragging = true;
+          try { pin.setPointerCapture(ev.pointerId); } catch (e) {}
+        }
+        em.preventDefault();
         var nb = pin.__box.getBoundingClientRect();
         pin.style.left = Math.max(4, Math.min(em.clientX - sx, nb.width - 40)) + "px";
         pin.style.top = Math.max(4, Math.min(em.clientY - sy, nb.height - 28)) + "px";
         updateLine(pin);
       }
-      function up() { pin.removeEventListener("pointermove", mv); pin.removeEventListener("pointerup", up); }
-      pin.addEventListener("pointermove", mv);
-      pin.addEventListener("pointerup", up);
+      function up() {
+        window.removeEventListener("pointermove", mv);
+        window.removeEventListener("pointerup", up);
+        window.removeEventListener("pointercancel", up);
+        try { pin.releasePointerCapture(ev.pointerId); } catch (e) {}
+      }
+      window.addEventListener("pointermove", mv);
+      window.addEventListener("pointerup", up);
+      window.addEventListener("pointercancel", up);
     });
 
     /* grip-to-resize via scale() (clientX throughout, matching drag, so a
@@ -143,9 +158,15 @@
         var s = Math.min(2.4, Math.max(0.5, startScale + (em.clientX - startX) / baseW));
         pin.__scale = s; pin.style.transform = "scale(" + s + ")"; updateLine(pin);
       }
-      function up() { grip.removeEventListener("pointermove", mv); grip.removeEventListener("pointerup", up); }
-      grip.addEventListener("pointermove", mv);
-      grip.addEventListener("pointerup", up);
+      function up() {
+        window.removeEventListener("pointermove", mv);
+        window.removeEventListener("pointerup", up);
+        window.removeEventListener("pointercancel", up);
+        try { grip.releasePointerCapture(ev.pointerId); } catch (e) {}
+      }
+      window.addEventListener("pointermove", mv);
+      window.addEventListener("pointerup", up);
+      window.addEventListener("pointercancel", up);
     });
     grip.addEventListener("dblclick", function () {
       pin.__scale = 1; pin.style.transform = ""; updateLine(pin);

--- a/www/styles.css
+++ b/www/styles.css
@@ -970,7 +970,7 @@ svg.smt-pin-lines {
 .smt-pin-rar { font-size: 11px; color: var(--gold); font-weight: 600; }
 .smt-pin-stats { color: #aebfd6; font-size: 11.5px; }
 .smt-pin .smt-open {
-  display: inline-block; margin-top: 7px; padding: 2px 9px;
+  display: inline-flex; align-items: center; min-height: 30px; margin-top: 7px; padding: 7px 12px;
   color: #0C234B; background: var(--gold); border-radius: 6px;
   font-weight: 600; font-size: 11.5px; cursor: pointer;
 }


### PR DESCRIPTION
The deferred Size Lab review items (S4/S5/S7/S8), all verified in preview.

- **S4 — fit line population.** The adult size–mass line is now fit on the **dots actually shown** (per-individual adult means, respecting the plot filter), SMA slope, labelled with **their** r — so the line + r describe what's on screen, not a different (all-plots, per-capture) population. (D. merriami adults now draw a line at r=0.40, where the old all-plots per-capture r fell under the 0.3 gate.)
- **S5 — overplotting.** Deterministic, tagID-keyed sub-pixel **jitter** so individuals that round to identical (hind-foot, weight) coords fan out and each stays individually tappable; **hover + pin card still report the TRUE measured means** (folded into trace text). The gold tracking diamond jitters by the same amount so it sits on its dot.
- **S7 — pointer-capture leak.** Drag/resize `move`/`up`/`cancel` now bound on **window** (not the element) + capture released on end, so a `pointerup` off the card (scroll-steal, edge swipe, `pointercancel`) can't leave a card stuck to the cursor.
- **S8 — touch target.** The "Open QC history card" chip is a ~**30px** tap target (was ~16px), and the drag needs **>4px** movement to engage — so a near-miss tap no longer starts a drag that swallows the click.

**Verified in preview:** binding intact (tap-to-pin works), dots jittered with true values in hover, fit line labelled with the shown dots' r, chip 30px, zero output errors. Manifest checksums bumped for server.R / pincards.js / styles.css.

🤖 Generated with [Claude Code](https://claude.com/claude-code)