### PR TITLE
fix: pooled detection p-hat mis-weighted in closed_capture_series (dplyr shadowing)

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1138,11 +1138,17 @@ closed_capture_series <- function(d, bouts = NULL) {
                 n_estimable = 0, mean_p = NA_real_, mean_detect = NA_real_))
   series <- est %>% dplyr::group_by(.data$ym) %>%
     dplyr::summarise(
+      # ckN / capt MUST be summed over the per-bout N̂ BEFORE `N` is reassigned to
+      # the month total below: within one summarise(), once `N = sum(.data$N)` runs,
+      # a later `.data$N` is that scalar month-sum, not the per-bout column — so
+      # ckN/capt (and thus pooled p̂ = capt/ckN) would silently use N_tot in place of
+      # N̂ᵢ in multi-grid months (the N_tot factor then cancels in p̂, leaving p̂
+      # k-weighted instead of the intended (k·N̂)-weighted). Keep these two first.
+      ckN = sum(.data$k * .data$N),
+      capt = sum(.data$p * .data$k * .data$N),   # = ΣCₜ recovered from p̂=ΣC/(kN)
       N = sum(.data$N),
       mnka = sum(.data$mnka),
       varN = sum(.data$varN, na.rm = TRUE),
-      ckN = sum(.data$k * .data$N),
-      capt = sum(.data$p * .data$k * .data$N),   # = ΣCₜ recovered from p̂=ΣC/(kN)
       n_grids = dplyr::n(), .groups = "drop") %>%
     dplyr::mutate(
       se = sqrt(pmax(.data$varN, 0)),


### PR DESCRIPTION
## What
`closed_capture_series()` ([R/helpers.R](R/helpers.R)) computed `ckN`/`capt` **after** `N` was reassigned to the month total inside the same `summarise()`, so dplyr's within-call column visibility made `sum(.data$k * .data$N)` use the scalar month-sum instead of the per-bout N̂.

## Effect
In **multi-grid months only**, pooled detection `p̂ = capt/ckN` came out **k-weighted** instead of the intended **(k·N̂)-weighted** (the code comment specifies pooling as `ΣC / Σ(k·N̂)`). Single-grid months collapse to one term and were unaffected. `mean_p` / `mean_detect` are computed separately from `est$` and were already correct, so the site-level "detection ~X%/night" card was not affected — only the per-month series `p` column.

## Fix
Move `ckN`/`capt` (the per-bout-N̂ sums) **before** the `N = sum(.data$N)` reassignment.

## Verification
Synthetic 2-grid month (k={3,3}, N̂={10,20}, p={0.5,0.2}):
- buggy `p̂` = **0.350** (k-weighted) · ckN=180, capt=63
- fixed `p̂` = **0.300** — matches intended `ΣC/Σ(k·N̂)` · ckN=90, capt=27
- `N`/`mnka`/`varN` unchanged

## Provenance
Found by a suite-wide audit after the same dplyr column-shadowing bug was fixed in NEON-Plant-Phenology's `plot_summary_phe()`. The other 6 audited NEON apps were clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)