### PR TITLE
fix(deploy): pin terra 1.8-50 so it compiles on Connect's GDAL 3.4.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2638,7 +2638,7 @@
         "Package": "terra",
         "Type": "Package",
         "Title": "Spatial Data Analysis",
-        "Version": "1.9-34",
+        "Version": "1.8-50",
         "Date": "2026-06-18",
         "Depends": "R (>= 3.5.0), methods",
         "Suggests": "parallel, tinytest, ncdf4, sf (>= 0.9-8), igraph, deldir,\nXML, leaflet (>= 2.2.1), htmlwidgets, future, future.apply",
@@ -2665,7 +2665,7 @@
         "RemoteRef": "terra",
         "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/noble/latest",
         "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-24.04",
-        "RemoteSha": "1.9-34"
+        "RemoteSha": "1.8-50"
       }
     },
     "tibble": {

--- a/scripts/write_manifest.R
+++ b/scripts/write_manifest.R
@@ -106,7 +106,26 @@ mtxt <- gsub("https://packagemanager.posit.co/cran/latest",
 mtxt <- gsub("https://cloud.r-project.org",
              "https://packagemanager.posit.co/cran/__linux__/jammy/latest", mtxt, fixed = TRUE)
 writeLines(mtxt, "manifest.json")
-cat("Repo pinned to RSPM jammy binary mirror (terra/sf install precompiled on Connect Cloud).\n")
+cat("Repo set to RSPM jammy mirror.\n")
+
+# ---- pin terra to the last release before the GDAL-3.8 multidim code --------
+# The jammy repo above is NECESSARY BUT NOT SUFFICIENT: Connect Cloud compiles terra
+# from source regardless of the repo, against its system GDAL 3.4.1 (Ubuntu jammy).
+# terra's multidimensional support (gdal_multidimensional.cpp, which calls the 3-arg
+# GDALMDArray::AsClassicDataset — a GDAL 3.8 overload, unguarded in released versions)
+# landed in terra 1.8-54, so every terra >= 1.8-54 FAILS to compile on GDAL 3.4.1.
+# Pin terra to 1.8-50 (last release before 1.8-54): no GDAL-3.8 code -> compiles on
+# 3.4.1, and still satisfies raster's `terra (>= 1.8-5)`. terra/raster are install-only
+# deps (leaflet -> raster -> terra; the app uses leaflet for maps and never calls
+# terra), so an older terra has ZERO runtime impact.
+TERRA_PIN <- "1.8-50"
+mm <- jsonlite::fromJSON("manifest.json", simplifyVector = FALSE)
+if (!is.null(mm$packages$terra)) {
+  mm$packages$terra$description$Version <- TERRA_PIN
+  if (!is.null(mm$packages$terra$description$RemoteSha)) mm$packages$terra$description$RemoteSha <- TERRA_PIN
+  jsonlite::write_json(mm, "manifest.json", auto_unbox = TRUE, pretty = TRUE, null = "null")
+  cat(sprintf("Pinned terra to %s (pre-GDAL-3.8-multidim; compiles on Connect's GDAL 3.4.1).\n", TERRA_PIN))
+}
 
 # ---- hard gate: a leaked heavy package must NEVER commit silently ----------
 m   <- jsonlite::fromJSON("manifest.json", simplifyVector = FALSE)


### PR DESCRIPTION
## Why SMT is still down after #61
#61 swapped the repo to RSPM jammy binaries, but **Connect Cloud compiles terra from source regardless**, against its system **GDAL 3.4.1** (Ubuntu jammy). terra's multidimensional code (`gdal_multidimensional.cpp`, which calls the 3-arg `GDALMDArray::AsClassicDataset` — a **GDAL 3.8** overload, unguarded in released terra) landed in **terra 1.8-54**, so every terra ≥ 1.8-54 (incl. the pinned 1.9-34) fails to compile on GDAL 3.4.1.

## Fix (identical to the one that brought Plant Phenology back up)
Pin terra to **1.8-50** — the last release *before* 1.8-54, so it has no GDAL-3.8 code and compiles on 3.4.1. It still satisfies `raster 3.6-32`'s `terra (>= 1.8-5)`, so **leaflet/raster are untouched**. terra/raster are install-only deps (the app uses leaflet for maps and never calls terra) → **zero runtime impact**.

- `manifest.json`: terra `1.9-34 → 1.8-50` (2 lines).
- `write_manifest.R`: re-pin terra to 1.8-50 after regen, so the **monthly CI refresh can't reintroduce** a ≥1.8-54 version and re-break the deploy.

Verified: manifest + generator parse clean; terra 1.8-50; raster floor satisfied. **PP is live with this exact pin.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)