### PR TITLE
Close the monthly-refresh loop with pre- and post-deploy verification

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -130,6 +130,13 @@ jobs:
       - name: Regenerate the manifest
         run: Rscript scripts/write_manifest.R
 
+      # PRE-DEPLOY VERIFICATION GATE. Check the rebuilt bundles, indexes, and the
+      # manifest BEFORE the push (which is the deploy). If this fails the job stops
+      # here, the push never happens, and Connect Cloud keeps serving the last
+      # known-good snapshot instead of a truncated/stale refresh.
+      - name: Verify rebuilt bundle (pre-deploy gate)
+        run: Rscript scripts/verify_bundle.R
+
       # Commit + push refreshed data DIRECTLY to main — THIS is the deploy: the push
       # makes Connect Cloud auto-republish (no human merge in the loop, matching the
       # siblings). Guarded so it no-ops cleanly when nothing changed.
@@ -162,4 +169,64 @@ jobs:
                        -m "${FRESH}; ${ENV}; index rebuilt."
             git push origin HEAD:main
             echo "Pushed refreshed data to main — Connect Cloud will redeploy. (${FRESH}; ${ENV})"
+          fi
+
+  # POST-DEPLOY VERIFICATION. Closes the loop: after the refresh job pushes (which
+  # triggers the Connect Cloud republish), confirm the LIVE app + landing page
+  # actually come back up. Cold-start aware (Connect workers wake slowly). Runs
+  # only on real refresh runs (first Saturday or a manual dispatch), NOT on the
+  # every-Saturday no-op gate. A failure here opens/updates a GitHub issue so a
+  # silent post-deploy outage is loud instead of a missed red check.
+  verify_live:
+    needs: [gate, refresh]
+    if: needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write          # open/update the outage issue on failure
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Smoke-check the live surfaces
+        id: smoke
+        run: |
+          # Give Connect Cloud a head start to notice the push before we poll.
+          sleep 30
+          bash scripts/post_deploy_smoke.sh \
+            "Connect Cloud app=https://019ec337-7100-317e-5052-c3bf32ffcb79.share.connect.posit.cloud/" \
+            "GitHub Pages landing=https://tgilbert14.github.io/NEON-Small-Mammal-Tracker-App/" \
+            | tee smoke.log
+          # Propagate the script's exit code (tee would otherwise mask it).
+          exit "${PIPESTATUS[0]}"
+
+      - name: Open/update outage issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="🔴 Post-deploy: live app did not come back up after refresh"
+          BODY=$(cat <<EOF
+          The monthly refresh pushed to \`main\` but the post-deploy smoke check could not
+          confirm the live surfaces are up (cold-start budget exhausted).
+
+          Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          \`\`\`
+          $(sed -n 's/^  //p' smoke.log 2>/dev/null | tail -n 20)
+          \`\`\`
+
+          If Connect Cloud is just slow, re-run the smoke or open the app manually; if it
+          stays down, check the Connect Cloud build log for a package-install/deploy failure.
+          EOF
+          )
+          # Dedup: reuse an open issue with this title instead of stacking new ones.
+          NUM=$(gh issue list --state open --search "$TITLE in:title" --json number \
+                  --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$NUM" ]; then
+            gh issue comment "$NUM" --body "$BODY"
+            echo "Updated existing outage issue #$NUM"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" --label "uptime" 2>/dev/null \
+              || gh issue create --title "$TITLE" --body "$BODY"
+            echo "Opened new outage issue"
           fi

--- a/scripts/post_deploy_smoke.sh
+++ b/scripts/post_deploy_smoke.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# post_deploy_smoke.sh — post-deploy liveness check for the refresh loop.
+#
+# After the monthly refresh pushes to main, Connect Cloud republishes the app.
+# This closes the loop: it confirms the LIVE surfaces actually come back up. It is
+# cold-start aware — a Connect Cloud worker can take a minute-plus to wake, so each
+# URL is polled with backoff for up to ~5 minutes before it is declared down.
+#
+# Usage:  post_deploy_smoke.sh "<label>=<url>" ["<label>=<url>" ...]
+# Exit 0 if every URL returns a healthy status within the retry budget; 1 otherwise.
+# On failure the refresh workflow opens/updates a GitHub issue (see refresh-data.yml).
+
+set -uo pipefail
+
+MAX_ATTEMPTS="${SMOKE_MAX_ATTEMPTS:-10}"   # ~10 tries
+SLEEP_BASE="${SMOKE_SLEEP_BASE:-5}"        # 5s,10s,15s... capped — ~5 min total
+CONNECT_TIMEOUT="${SMOKE_CONNECT_TIMEOUT:-15}"
+MAX_TIME="${SMOKE_MAX_TIME:-45}"
+
+fail=0
+report=""
+
+check_one() {
+  local label="$1" url="$2" attempt code
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    # Follow redirects; a 2xx or 3xx final code counts as up. Connect Cloud can
+    # answer 200 while still waking, which is fine — we only care it responds.
+    code=$(curl -sS -o /dev/null -w '%{http_code}' -L \
+                --connect-timeout "$CONNECT_TIMEOUT" --max-time "$MAX_TIME" \
+                -A 'ddl-uptime-smoke/1.0' "$url" 2>/dev/null || echo "000")
+    if [[ "$code" =~ ^(2|3)[0-9][0-9]$ ]]; then
+      echo "  ok   [$label] $url -> $code (attempt $attempt)"
+      return 0
+    fi
+    echo "  wait [$label] $url -> $code (attempt $attempt/$MAX_ATTEMPTS)"
+    local nap=$(( SLEEP_BASE * attempt )); (( nap > 40 )) && nap=40
+    sleep "$nap"
+  done
+  echo "  DOWN [$label] $url -> last=$code after $MAX_ATTEMPTS attempts"
+  return 1
+}
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 '<label>=<url>' ..." >&2
+  exit 2
+fi
+
+for spec in "$@"; do
+  label="${spec%%=*}"
+  url="${spec#*=}"
+  echo "checking $label ..."
+  if ! check_one "$label" "$url"; then
+    fail=1
+    report+="- **${label}** is DOWN: ${url}"$'\n'
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "SMOKE_REPORT<<EOF"        # captured by the workflow to build the issue body
+  printf '%s' "$report"
+  echo "EOF"
+  echo "post-deploy smoke FAILED" >&2
+  exit 1
+fi
+echo "post-deploy smoke PASSED — all surfaces live."

--- a/scripts/verify_bundle.R
+++ b/scripts/verify_bundle.R
@@ -1,0 +1,103 @@
+#!/usr/bin/env Rscript
+# verify_bundle.R — pre-deploy integrity gate for the monthly refresh loop.
+#
+# THE VERIFICATION BOX. The refresh workflow rebuilds the per-site bundles, the
+# indexes, and the manifest, then pushes to main — and that push IS the deploy
+# (Connect Cloud auto-republishes). Nothing used to check the rebuilt artifacts
+# before that push, so a truncated NEON pull or a stale index could ship silently
+# and Connect Cloud would serve it. This script runs AFTER the rebuild and BEFORE
+# the push: if it stop()s, the job fails, the push never happens, and Connect Cloud
+# keeps serving the last known-good bundle.
+#
+# Checks (all non-network, run on both the full-pull and skip-download paths):
+#   1. data/sites/*.rds  — at least one exists, every one loads without error and
+#      is a data.frame; at least one has rows (not every site is empty).
+#   2. data/site_index.rds, data/search_index.rds, data/species_ranges.rds — each
+#      loads and has > 0 rows (these drive the map, the search tab, and ranges).
+#   3. manifest.json — parses as JSON and every runtime file it lists exists on
+#      disk. This is the exact Connect Cloud failure mode DEPLOY.md warns about:
+#      a manifest whose file list/checksums drift from the bundles makes Connect
+#      serve the OLD snapshot.
+#
+# Exit non-zero (via stop()) on any hard failure. Emits a GitHub Actions
+# ::error:: annotation for each so the failure is legible in the run log.
+
+`%||%` <- function(a, b) if (is.null(a) || length(a) == 0) b else a
+
+problems <- character(0)
+note <- function(msg) { problems[[length(problems) + 1L]] <<- msg }
+gha_error <- function(msg) cat(sprintf("::error title=Bundle verification::%s\n", msg))
+
+rows_of <- function(x) {
+  n <- tryCatch(nrow(x), error = function(e) NA_integer_)
+  if (is.null(n)) NA_integer_ else n
+}
+
+# ---- 1. per-site bundles -----------------------------------------------------
+site_files <- list.files("data/sites", pattern = "\\.rds$", full.names = TRUE)
+if (length(site_files) == 0L) {
+  note("data/sites/ contains no .rds bundles — refresh produced nothing to deploy.")
+} else {
+  loaded_ok <- 0L; with_rows <- 0L
+  for (f in site_files) {
+    obj <- tryCatch(readRDS(f), error = function(e) e)
+    if (inherits(obj, "error")) {
+      note(sprintf("bundle failed to load: %s (%s)", f, conditionMessage(obj)))
+      next
+    }
+    loaded_ok <- loaded_ok + 1L
+    n <- rows_of(obj)
+    if (!is.na(n) && n > 0L) with_rows <- with_rows + 1L
+  }
+  cat(sprintf("sites: %d file(s), %d loaded, %d with rows\n",
+              length(site_files), loaded_ok, with_rows))
+  if (loaded_ok < length(site_files))
+    note(sprintf("%d of %d site bundle(s) failed to load — likely corrupt/truncated.",
+                 length(site_files) - loaded_ok, length(site_files)))
+  if (with_rows == 0L)
+    note("every site bundle is empty (0 rows) — a refresh this empty is almost certainly a bad NEON pull.")
+}
+
+# ---- 2. top-level indexes ----------------------------------------------------
+for (idx in c("data/site_index.rds", "data/search_index.rds", "data/species_ranges.rds")) {
+  if (!file.exists(idx)) { note(sprintf("missing index: %s", idx)); next }
+  obj <- tryCatch(readRDS(idx), error = function(e) e)
+  if (inherits(obj, "error")) {
+    note(sprintf("index failed to load: %s (%s)", idx, conditionMessage(obj))); next
+  }
+  n <- rows_of(obj)
+  if (is.na(n) || n <= 0L)
+    note(sprintf("index has no rows: %s (nrow=%s)", idx, n %||% "NA"))
+  else
+    cat(sprintf("index ok: %s (%d rows)\n", idx, n))
+}
+
+# ---- 3. manifest ↔ bundle coherence -----------------------------------------
+if (!file.exists("manifest.json")) {
+  note("manifest.json is missing — Connect Cloud deploys from it.")
+} else {
+  man <- tryCatch(jsonlite::fromJSON("manifest.json", simplifyVector = FALSE),
+                  error = function(e) e)
+  if (inherits(man, "error")) {
+    note(sprintf("manifest.json is not valid JSON (%s)", conditionMessage(man)))
+  } else {
+    files <- man$files
+    if (is.null(files) || length(files) == 0L) {
+      note("manifest.json lists no files — writeManifest output looks empty.")
+    } else {
+      missing <- names(files)[!file.exists(names(files))]
+      cat(sprintf("manifest lists %d file(s)\n", length(files)))
+      if (length(missing) > 0L)
+        note(sprintf("manifest references %d file(s) not on disk (Connect would serve a stale snapshot): %s",
+                     length(missing), paste(utils::head(missing, 8L), collapse = ", ")))
+    }
+  }
+}
+
+# ---- verdict -----------------------------------------------------------------
+if (length(problems) > 0L) {
+  for (p in problems) gha_error(p)
+  stop(sprintf("Bundle verification FAILED with %d problem(s) — refusing to deploy. See ::error:: annotations above.",
+               length(problems)), call. = FALSE)
+}
+cat("\nBundle verification PASSED — safe to deploy.\n")


### PR DESCRIPTION
## What & why

The monthly `refresh-data.yml` rebuilds the per-site bundles, indexes, and manifest, then pushes to `main` — and that push **is** the deploy (Connect Cloud auto-republishes). Nothing verified the result, so a truncated NEON pull or a stale index could ship silently and Connect would serve it. This adds the two missing **verification boxes** so the loop closes.

## Changes

- **`scripts/verify_bundle.R`** — pre-deploy integrity gate. Runs after the rebuild and **before** the push:
  - every `data/sites/*.rds` loads and at least one has rows;
  - `data/site_index.rds`, `data/search_index.rds`, `data/species_ranges.rds` load and have rows;
  - `manifest.json` parses and every file it lists exists on disk (the exact Connect Cloud stale-snapshot failure mode `DEPLOY.md` warns about).

  If it `stop()`s, the job fails, **the push never happens**, and Connect keeps serving the last known-good bundle.
- **`scripts/post_deploy_smoke.sh` + a new `verify_live` job** — post-deploy liveness. After the push, cold-start-aware smoke-check of the live Connect Cloud app and the GitHub Pages landing; on failure it opens/updates a **deduped GitHub issue** (`issues: write`) so a silent post-deploy outage is loud.
- **`refresh-data.yml`** — wires the pre-deploy step before the commit/push and adds the `verify_live` job (`needs: [gate, refresh]`, runs only on real refresh runs).

## Verification

- Workflow YAML parses; `verify_bundle.R` is brace/paren-balanced; `post_deploy_smoke.sh` passes `bash -n`. R itself isn't in the review sandbox, so I recommend a one-click **`workflow_dispatch` with `skip_download=true`** after merge to exercise `verify_bundle.R` against the committed bundle (fast, no NEON pull) and the liveness job against the live app.

No secrets added — uses the built-in `GITHUB_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ki3cxpK7JGroz3oSYAgBJM)_