### PR TITLE
Add agent context so subagents boot smart in this repo

### DIFF
--- a/.claude/agents/LESSONS.md
+++ b/.claude/agents/LESSONS.md
@@ -1,0 +1,23 @@
+# LESSONS — NEON Small Mammal Tracker (project-local)
+
+> Project-specific institutional memory for THIS app. Agents boot cold: read this on start (grep for your
+> own name, `· <agent> ·`) and append a one-line lesson after a run that taught something durable.
+>
+> The **canonical, cross-cutting** log lives in `TG-Data-Apps/.claude/agents/LESSONS.md`; the deep NEON
+> methodology lives in `docs/neonize-playbook.md`. `curator` promotes recurring lessons up to the canonical
+> log and into the owning agent's `.md`. Format + protocol: `TG-Data-Apps/.claude/agents/_CONVENTIONS.md`.
+
+## How to write an entry
+```
+- [YYYY-MM-DD] <agent> · <verdict: confirmed|over-flagged|wrong|gap> · <the durable lesson, one line>
+```
+
+## Lessons
+
+<!-- newest at the bottom; append, don't rewrite history. Seeded 2026-07 from the playbook + connor. -->
+- [2026-07-01] connor · confirmed · Pin `terra` to `1.8-50` in `manifest.json` (Connect's GDAL 3.4.1 can't compile terra ≥ 1.8-54's GDAL-3.8 multidim code; leaflet→raster→terra; install-only, zero runtime impact). This app's CI regenerates the manifest, so the re-pin must ALSO live in the manifest-writing step or the monthly refresh re-breaks the deploy.
+- [2026-07-01] neonize · confirmed · Deploy = direct `git push` to `main` (Connect Cloud auto-republishes); no shinyapps secrets, no `deploy.R`. Confirm the build goes GREEN — a failed publish silently leaves the previous good build serving, so "the app still loads" is not proof your change deployed.
+- [2026-07-01] neonize · gap · `skip_download` in `refresh-data.yml` must gate BOTH the fetch AND the bundle step, or the bundler runs on missing `<SITE>_raw.rds` and dies.
+- [2026-07-01] hadley · confirmed · dplyr `summarise()` evaluates sequentially — the flagship's `id_uncertain` flag read a modal length-1 scalar and fired 0/93,169 despite a real ~4–12% congener-swap rate. Recompute a QC flag's base rate from raw data; a flag that fires 0 times is guilty until proven innocent.
+- [2026-07-01] neonize · confirmed · Recompute any landing/README headline straight from the `.rds` (a one-line `count()`/`cor()`) — it caught "140+ species" that was actually 145.
+- [2026-07-01] mara · confirmed · Label the abundance metric honestly: MNKA and CPUE are indices, not population size; detection-corrected N̂ (Schnabel ≥3 nights / Chapman 2) needs enough recaptures or it's gated. A detection-index ≠ a population.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# NEON Small Mammal Tracker — working context for Claude
+
+> Read this first. It orients an agent that boots cold in this repo. Depth lives in the docs it points at.
+> This is a **Desert Data Labs (DDL)** project; the DDL business context + the full agent suite live in the
+> `TG-Data-Apps` repo (and in user scope, so every agent is available here too).
+
+## What this is
+
+A **Shiny web app** exploring NEON's **small-mammal box-trapping** data product (**DP1.10072.001**) — it
+reconstructs each captured animal's history from its ear-tag and turns ~46 field sites of capture records
+into maps, per-individual profiles, abundance estimates, and diversity reads. It is the **flagship** of the
+DDL **NEON explorer suite** and the reference build every sibling app is measured against.
+
+- **Live:** https://tgilbert14.github.io/NEON-Small-Mammal-Tracker-App/ (landing) → the app on **Posit
+  Connect Cloud**, which auto-republishes on push to `main`.
+- **Stack:** R / Shiny · `global.R` + `server.R` + `ui.R` + `R/*.R` helpers · per-site `.rds` data bundles
+  (no network round-trip at runtime) · Leaflet maps · `manifest.json` for Connect Cloud.
+
+## The stack + how it deploys (the load-bearing facts)
+
+- **Deploy = `git push` to the watched branch.** Connect Cloud is git-backed; pushing the refreshed bundle
+  IS the deploy. No shinyapps secrets. See `DEPLOY.md` (Option A) and, for the whole methodology,
+  `docs/neonize-playbook.md`.
+- **The terra/GDAL landmine (the #1 publish killer).** Connect compiles native packages from source on
+  jammy (**GDAL 3.4.1**); `leaflet → raster → terra`, and terra ≥ 1.8-54 needs GDAL 3.8 → **pin `terra` to
+  `1.8-50`** in `manifest.json`. This app's CI (`.github/workflows/refresh-data.yml`) regenerates the
+  manifest, so the re-pin must also live in the manifest-writing step or the monthly refresh re-breaks the
+  deploy. **For any deploy/manifest failure, that's `connor`'s territory; for the build methodology, `neonize`.**
+- **Auto-refresh:** `refresh-data.yml` runs monthly (first-Saturday gate, off-peak AZ), rebuilds the bundles,
+  and pushes. A `skip_download` input gates BOTH the fetch and the bundle step (fast pipeline test).
+- **Migrating off shinyapps.io** (sunsets end-2026) → Connect Cloud is the standard; some legacy bits remain.
+
+## Which agents own what here
+
+- **`neonize`** — the suite methodology: build/upgrade this or a sibling to the gold standard, the QC-flag
+  system, site-picker map contract, auto-refresh CI, suite cohesion. Reads/writes `docs/neonize-playbook.md`.
+- **`connor`** — Connect Cloud deploy: failed publishes, the terra pin, manifest correctness, redeploy.
+- **`mara`** — the DP1.10072.001 domain expert (small-mammal trapping science: MNKA vs CPUE vs Schnabel/
+  Chapman, mark-recapture, tag identity). **`cass`** — the cross-product Driver-Cascade synthesis.
+- **`hk`** and its stats team (Hadley, Tukey, Fisher, Stan, Hutch, Tobler, Tufte, Joe, Few) — the statistics.
+- **`vgs` (R/Shiny mode)** — a full team review of the app.
+- Call any of them by name (`run neonize`, `ask connor`, `run HK`); they're installed in user scope.
+
+## The learning loop (this repo)
+
+- **`.claude/agents/LESSONS.md`** — project-local, one-line lessons for THIS app. Agents read it on cold
+  boot and append to it after a durable run. The **canonical, cross-cutting** LESSONS.md lives in
+  `TG-Data-Apps`; `curator` promotes recurring lessons up.
+- **`docs/neonize-playbook.md`** — the deep methodology playbook (the real learning surface for the suite);
+  `docs/project-status.md` — current version + open items + what's deferred. Read both before flagging work.
+
+## Working notes
+
+- **Default the demo/example site to SRER** (or an AZ/desert site) — DDL is AZ-based and the desert is the
+  clearest story.
+- **Honesty discipline:** the caveat goes ON the number (detection-index ≠ population; n-gate short series;
+  publish match rates; snapshot-not-pooled). Recompute any headline count straight from the `.rds` before
+  trusting it, and recompute a QC flag's base rate from the raw data — a flag that fires 0 times is guilty
+  until proven innocent.

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -1,0 +1,37 @@
+# Project status — NEON Small Mammal Tracker
+
+> The context file the coordinators (`vgs`, `hk`, `neonize`) inject into every specialist brief so a
+> cold-booted agent doesn't re-flag shipped or deliberately-deferred work. Owned by `triage`; keep it
+> current after every review or ship. Depth: `README.md`, `DEPLOY.md`, `docs/neonize-playbook.md`.
+
+**Last verified against the build:** 2026-07-01 (agent sweep — content below carried from README/DEPLOY/playbook; re-verify against HEAD before trusting a specific claim).
+
+## Stage
+- **Live** on Posit Connect Cloud (auto-republish on push to `main`); GitHub Pages landing fronts it.
+- The **flagship / reference** app of the NEON explorer suite — the gold standard siblings are measured against.
+
+## Shipped (don't re-flag as missing)
+- National site-picker Leaflet map (by-site / by-species toggle, accessible list fallback, one-tap load).
+- Per-site `.rds` bundles (instant load, no runtime network call); ~46 sites, 145 species.
+- Detection-corrected abundance (Schnabel ≥3 nights / Chapman 2), MNKA, per-night detection, gated + clamped.
+- Hill-number diversity profile; per-individual dossiers + holographic trading-card export; site compare; PDF report card.
+- QC-flag system (ranked "verify, not wrong" flags + downloadable offending rows).
+- Auto-refresh CI (`refresh-data.yml`, monthly first-Saturday gate, `skip_download` fast path), now with
+  pre-deploy bundle verification (`scripts/verify_bundle.R`) + post-deploy smoke (`scripts/post_deploy_smoke.sh`)
+  — the refresh loop is closed (verify before and after deploy).
+
+## Open / in-flight
+- **Migration off shinyapps.io → Connect Cloud** (shinyapps sunsets end-2026): the standard for the suite;
+  confirm this app is fully on Connect Cloud and retire any legacy `rsconnect/shinyapps.io/` + `deploy.R`.
+- **terra 1.8-50 pin in the CI manifest regen** — the monthly refresh regenerates `manifest.json`, so the
+  re-pin must live in the manifest-writing step or the refresh re-breaks the deploy (see `connor`).
+- Long-term: Shinylive/WebAssembly static export (zero cold-start endgame) — see `DEPLOY.md` Option B.
+
+## Deliberately deferred / non-goals
+- Not a framework rewrite; not a multi-tenant app (it's a single public explorer).
+- Live NEON API calls at runtime are intentionally avoided (bundled `.rds` is the design).
+
+## P-items
+- **P1:** confirm terra pin survives the CI manifest regen (deploy stays green after a monthly refresh).
+- **P2:** finish/verify the shinyapps→Connect Cloud retirement.
+- **P3:** evaluate Shinylive static export.


### PR DESCRIPTION
## What this is

Part of the Desert Data Labs **agent sweep** (main changes are in `TG-Data-Apps`). The agents install to user scope and run here, but this repo had no local context — so they booted blind. This adds the three files the suite's cold-boot protocol expects.

## Changes

- **`CLAUDE.md`** — project context for a cold-booting agent: the DP1.10072.001 flagship, the Posit Connect Cloud git-backed deploy model, the **terra 1.8-50 / GDAL 3.4.1** landmine, and which agents own what here (`neonize`, `connor`, `mara`, `cass`, the HK stats team).
- **`docs/project-status.md`** — current stage + shipped features + open items + deliberately-deferred work. This is the file the `vgs`/`hk`/`neonize` coordinators inject into every specialist brief so a cold-booted agent doesn't re-flag shipped or parked work.
- **`.claude/agents/LESSONS.md`** — the project-local learning log (seeded from `docs/neonize-playbook.md` + `connor`): read on cold boot, appended after a durable run. The canonical cross-cutting log lives in `TG-Data-Apps`; `curator` promotes recurring lessons up.

Content was carried from the existing `README.md` / `DEPLOY.md` / `docs/neonize-playbook.md`; nothing about the app itself changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iRwTFFG1xMedSA4g369kQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011iRwTFFG1xMedSA4g369kQ)_