### PR TITLE
fix(ci): install rsconnect so the refresh manifest step can run

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -74,13 +74,17 @@ jobs:
         with:
           use-public-rspm: true
 
+      # rsconnect is a BUILD-TIME tool: scripts/write_manifest.R calls
+      # rsconnect::writeManifest(). It is pruned out of the final manifest by the
+      # RUNTIME_PKGS reachability walk in that script, so it never ships to Connect.
       - name: Install R packages
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           packages: >
             neonUtilities, dplyr, tibble, tidyr, stringr, jsonlite,
             shiny, bslib, bsicons, plotly, leaflet, DT, shinyjs,
-            shinycssloaders, RColorBrewer, htmltools, cpp11
+            shinycssloaders, RColorBrewer, htmltools, cpp11,
+            rsconnect
 
       - name: Rebuild the per-site bundle (full NEON re-pull)
         if: ${{ github.event.inputs.skip_download != 'true' }}


### PR DESCRIPTION
## What & why

A `workflow_dispatch` test of `refresh-data.yml` (triggered to verify the new pre-deploy gate from #68) surfaced a **pre-existing** failure: the **Regenerate the manifest** step runs `scripts/write_manifest.R`, which calls `rsconnect::writeManifest()`, but the *Install R packages* list omitted `rsconnect`:

```
Error in library(rsconnect) : there is no package called 'rsconnect'
```

The step dies before the push (and before the new `verify_bundle.R` gate), so **the whole refresh loop can't complete**. This was latent — the manifest step hadn't been exercised by CI since it was added; my dispatch was the first run to reach it.

## Fix

Add `rsconnect` to the workflow's package install list. It's a build-time tool only: `write_manifest.R`'s `RUNTIME_PKGS` reachability prune drops it from the final `manifest.json`, so it never ships to Connect Cloud (verified against the prune logic — `rsconnect` isn't reachable from the runtime app packages).

## Verification

- YAML parses; the `packages` folded scalar resolves to a clean 18-package comma list ending in `rsconnect`, with no comment leaked into the value.
- After merge I'll re-run the `skip_download=true` dispatch to confirm the full workflow (manifest → `verify_bundle.R` gate → `verify_live` smoke) goes green.

Not part of the #68 loop change — a distinct, additive CI fix that unblocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ki3cxpK7JGroz3oSYAgBJM)_