### PR TITLE
Fix Connect dependency repository URLs

### DIFF
--- a/docs/BUILD-TEST-HANDOFF.md
+++ b/docs/BUILD-TEST-HANDOFF.md
@@ -453,3 +453,34 @@ Driver implication, and next action.
   compatibility, or checksum evidence.
 - **Next action:** statically verify and push this exact canonicalization, then require
   one green exact-head run before readying PR #73.
+
+### 2026-07-18 15:08 MST - production exposed a manifest network-contract gap
+
+- **Merged evidence:** PR #73 merged as
+  `6df138c316a1dc71ac9ee3960120c7716a53e92d`. Exact-head run `29655948807`
+  and merge run `29656583272` both passed the complete pinned validator ladder.
+- **Semantic evidence (FAIL):** post-deploy run `29656583275` correctly opened outage
+  issue #74 after the public endpoint continued to serve `Startup Error`. Signed-in
+  Connect inspection showed the content was still on July 8 commit `39dca56`; an
+  authorized republish fetched exact merged commit `6df138c` and then failed dependency
+  resolution with `Get "CRAN/src/contrib/Archive/wk/wk_0.9.5.tar.gz": unsupported
+  protocol scheme ""`.
+- **Root cause:** the installed package DESCRIPTION truthfully labels its repository
+  `CRAN`, but Connect treats the manifest package's top-level `Repository` value as a
+  network location. The validator proved package identity and origin but did not prove
+  that this field was a usable absolute URL. The result was reproducible in production;
+  it is not a data, application-runtime, R-version, or package-version failure.
+- **Focused correction:** canonicalization now changes only the eight exact URL
+  packages' top-level repository location to `https://cran.r-project.org`; each exact
+  tarball remains hard-gated in `RemotePkgRef`, and DESCRIPTION's own provenance is
+  preserved. Writer and independent verifier both require that deployable shape.
+  Canonical manifest SHA-256 is
+  `903a2617be4ca7b78fdf2f414f625bbcacea1b805d43c8360c5cee5f0e01971b`.
+- **Learning promoted:** release validation must distinguish installed-record truth
+  from the deployment platform's network contract. Future app/subagent briefs must
+  require absolute manifest repository URLs and a real Connect dependency-resolution
+  receipt before a package strategy becomes suite-standard.
+- **Next action:** require an exact-head green run for this focused correction, merge
+  through review, republish the resulting `main`, and rerun semantic health. Do not
+  close issue #74 or promote the production receipt until the public app exposes its
+  semantic ready marker.

--- a/docs/BUILD-TEST-HANDOFF.md
+++ b/docs/BUILD-TEST-HANDOFF.md
@@ -471,11 +471,14 @@ Driver implication, and next action.
   that this field was a usable absolute URL. The result was reproducible in production;
   it is not a data, application-runtime, R-version, or package-version failure.
 - **Focused correction:** canonicalization now changes only the eight exact URL
-  packages' top-level repository location to `https://cran.r-project.org`; each exact
-  tarball remains hard-gated in `RemotePkgRef`, and DESCRIPTION's own provenance is
-  preserved. Writer and independent verifier both require that deployable shape.
+  packages' top-level deployable lane to `Source: CRAN` and repository location to
+  `https://cran.r-project.org`; each exact installation tarball remains hard-gated in
+  `RemotePkgRef`, and DESCRIPTION's own provenance is preserved. This matches the last
+  healthy Connect manifest shape for the same package versions and lets Connect choose
+  current versus archive paths correctly. Writer and independent verifier both require
+  that deployable shape.
   Canonical manifest SHA-256 is
-  `903a2617be4ca7b78fdf2f414f625bbcacea1b805d43c8360c5cee5f0e01971b`.
+  `e619343d1d6404f52260481ec611ccbd1c9f5cd349657c0799f6d535a7bc0b11`.
 - **Learning promoted:** release validation must distinguish installed-record truth
   from the deployment platform's network contract. Future app/subagent briefs must
   require absolute manifest repository URLs and a real Connect dependency-resolution

--- a/docs/DRIVER-KNOWLEDGE-PACKAGE.md
+++ b/docs/DRIVER-KNOWLEDGE-PACKAGE.md
@@ -22,9 +22,11 @@ ledger because this file cannot self-pin a future merge commit.
   `45b5c82640a20b8c181b6b60949e20ebbeb9c5b0`
 - Validated raw manifest artifact: R 4.5.2, 91 packages, 117 files, SHA-256
   `3fba04eb885b3cb6a9437b8c8b25ade25d44d47f6dcb50add025e754a6de04d7`
-- Canonical release manifest: the same validated record with only the eight
-  wall-clock URL-package `Built` timestamps removed; SHA-256
-  `395fc36faa11f408a3ef4483f6c6ff2da13c09ab1f5d2498f2744bddbee0606c`
+- Canonical deployable manifest: the same validated record with the eight
+  wall-clock URL-package `Built` timestamps removed and their top-level repository
+  locations normalized from DESCRIPTION's symbolic `CRAN` label to the absolute
+  `https://cran.r-project.org` origin Connect requires; SHA-256
+  `903a2617be4ca7b78fdf2f414f625bbcacea1b805d43c8360c5cee5f0e01971b`
 - Bundle/index contract: 46/46 expected site bundles loaded with rows and the
   physical-effort schema; national index row counts are 46/604/604; 145 species.
 
@@ -117,12 +119,13 @@ Promote to every later app/subagent brief:
   closure; manifest generated from the installed runtime; exact checksum/offline boot
   gates; read-only CI; immutable reviewed release; semantic post-deploy health that
   opens an outage issue and closes it on recovery.
-- **Provenance:** URL installs must be validated using their emitted tuple
-  (`Source: URL`, `Repository: CRAN`, `RemoteType: url`, exact `RemotePkgRef`), never
-  by rewriting a manifest or accepting an assumed source shape. Failed candidates may
-  be retained briefly only when unmistakably labelled UNVALIDATED. Source-package
-  wall-clock `Built` timestamps must be deterministically removed while all identity,
-  origin, compatibility, and checksum fields remain hard-gated.
+- **Provenance:** validate both the installed-package record and the deployable
+  network contract. Direct URL installs retain `Source: URL`, `RemoteType: url`, and
+  exact `RemotePkgRef`; Connect's top-level `Repository` must be an absolute URL, not
+  DESCRIPTION's symbolic `CRAN` label. Failed candidates may be retained briefly only
+  when unmistakably labelled UNVALIDATED. Source-package wall-clock `Built` timestamps
+  must be deterministically removed while all identity, origin, compatibility, and
+  checksum fields remain hard-gated.
 - **Data/release UX:** report bundle freshness as reviewed/committed, not live; never
   turn an opaque no-CORS pre-warm into a readiness claim; automated data refreshes
   create restricted review candidates rather than writing production directly.

--- a/docs/DRIVER-KNOWLEDGE-PACKAGE.md
+++ b/docs/DRIVER-KNOWLEDGE-PACKAGE.md
@@ -23,10 +23,10 @@ ledger because this file cannot self-pin a future merge commit.
 - Validated raw manifest artifact: R 4.5.2, 91 packages, 117 files, SHA-256
   `3fba04eb885b3cb6a9437b8c8b25ade25d44d47f6dcb50add025e754a6de04d7`
 - Canonical deployable manifest: the same validated record with the eight
-  wall-clock URL-package `Built` timestamps removed and their top-level repository
-  locations normalized from DESCRIPTION's symbolic `CRAN` label to the absolute
-  `https://cran.r-project.org` origin Connect requires; SHA-256
-  `903a2617be4ca7b78fdf2f414f625bbcacea1b805d43c8360c5cee5f0e01971b`
+  wall-clock URL-package `Built` timestamps removed and their top-level deployment
+  lane normalized to `Source: CRAN` plus the absolute `https://cran.r-project.org`
+  origin Connect requires; SHA-256
+  `e619343d1d6404f52260481ec611ccbd1c9f5cd349657c0799f6d535a7bc0b11`
 - Bundle/index contract: 46/46 expected site bundles loaded with rows and the
   physical-effort schema; national index row counts are 46/604/604; 145 species.
 
@@ -120,12 +120,13 @@ Promote to every later app/subagent brief:
   gates; read-only CI; immutable reviewed release; semantic post-deploy health that
   opens an outage issue and closes it on recovery.
 - **Provenance:** validate both the installed-package record and the deployable
-  network contract. Direct URL installs retain `Source: URL`, `RemoteType: url`, and
-  exact `RemotePkgRef`; Connect's top-level `Repository` must be an absolute URL, not
-  DESCRIPTION's symbolic `CRAN` label. Failed candidates may be retained briefly only
-  when unmistakably labelled UNVALIDATED. Source-package wall-clock `Built` timestamps
-  must be deterministically removed while all identity, origin, compatibility, and
-  checksum fields remain hard-gated.
+  network contract. Direct URL installs retain `RemoteType: url` and exact
+  `RemotePkgRef` in DESCRIPTION metadata; Connect's top-level fields must use
+  `Source: CRAN` plus an absolute repository URL so current/archive resolution works.
+  Failed candidates may be retained briefly only when unmistakably labelled
+  UNVALIDATED. Source-package wall-clock `Built` timestamps must be deterministically
+  removed while all identity, origin, compatibility, and checksum fields remain
+  hard-gated.
 - **Data/release UX:** report bundle freshness as reviewed/committed, not live; never
   turn an opaque no-CORS pre-warm into a readiness claim; automated data refreshes
   create restricted review candidates rather than writing production directly.

--- a/manifest.json
+++ b/manifest.json
@@ -462,7 +462,7 @@
       }
     },
     "classInt": {
-      "Source": "URL",
+      "Source": "CRAN",
       "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "classInt",
@@ -2104,7 +2104,7 @@
       }
     },
     "raster": {
-      "Source": "URL",
+      "Source": "CRAN",
       "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "raster",
@@ -2210,7 +2210,7 @@
       }
     },
     "s2": {
-      "Source": "URL",
+      "Source": "CRAN",
       "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "s2",
@@ -2314,7 +2314,7 @@
       }
     },
     "sf": {
-      "Source": "URL",
+      "Source": "CRAN",
       "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "sf",
@@ -2481,7 +2481,7 @@
       }
     },
     "sp": {
-      "Source": "URL",
+      "Source": "CRAN",
       "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "sp",
@@ -2615,7 +2615,7 @@
       }
     },
     "terra": {
-      "Source": "URL",
+      "Source": "CRAN",
       "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "terra",
@@ -2796,7 +2796,7 @@
       }
     },
     "units": {
-      "Source": "URL",
+      "Source": "CRAN",
       "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "units",
@@ -2970,7 +2970,7 @@
       }
     },
     "wk": {
-      "Source": "URL",
+      "Source": "CRAN",
       "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "wk",

--- a/manifest.json
+++ b/manifest.json
@@ -463,7 +463,7 @@
     },
     "classInt": {
       "Source": "URL",
-      "Repository": "CRAN",
+      "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "classInt",
         "Version": "0.4-11",
@@ -2105,7 +2105,7 @@
     },
     "raster": {
       "Source": "URL",
-      "Repository": "CRAN",
+      "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "raster",
         "Type": "Package",
@@ -2211,7 +2211,7 @@
     },
     "s2": {
       "Source": "URL",
-      "Repository": "CRAN",
+      "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "s2",
         "Title": "Spherical Geometry Operators Using the S2 Geometry Library",
@@ -2315,7 +2315,7 @@
     },
     "sf": {
       "Source": "URL",
-      "Repository": "CRAN",
+      "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "sf",
         "Version": "1.1-1",
@@ -2482,7 +2482,7 @@
     },
     "sp": {
       "Source": "URL",
-      "Repository": "CRAN",
+      "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "sp",
         "Version": "2.2-1",
@@ -2616,7 +2616,7 @@
     },
     "terra": {
       "Source": "URL",
-      "Repository": "CRAN",
+      "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "terra",
         "Type": "Package",
@@ -2797,7 +2797,7 @@
     },
     "units": {
       "Source": "URL",
-      "Repository": "CRAN",
+      "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "units",
         "Version": "1.0-1",
@@ -2971,7 +2971,7 @@
     },
     "wk": {
       "Source": "URL",
-      "Repository": "CRAN",
+      "Repository": "https://cran.r-project.org",
       "description": {
         "Package": "wk",
         "Title": "Lightweight Well-Known Geometry Parsing",

--- a/scripts/verify_bundle.R
+++ b/scripts/verify_bundle.R
@@ -180,7 +180,8 @@ if (!file.exists("manifest.json")) {
           remote_ref <- as.character(x$description$RemotePkgRef %||% "")
           built <- as.character(x$description$Built %||% "")
           expected_ref <- paste0("url::", unname(EXPECTED_GEO_URLS[[pkg]]))
-          base_bad || !identical(source, "URL") || !identical(repo, "CRAN") ||
+          base_bad || !identical(source, "URL") ||
+            !identical(repo, "https://cran.r-project.org") ||
             !identical(remote_type, "url") ||
             !identical(remote_ref, expected_ref) || nzchar(built)
         } else {

--- a/scripts/verify_bundle.R
+++ b/scripts/verify_bundle.R
@@ -180,7 +180,7 @@ if (!file.exists("manifest.json")) {
           remote_ref <- as.character(x$description$RemotePkgRef %||% "")
           built <- as.character(x$description$Built %||% "")
           expected_ref <- paste0("url::", unname(EXPECTED_GEO_URLS[[pkg]]))
-          base_bad || !identical(source, "URL") ||
+          base_bad || !identical(source, "CRAN") ||
             !identical(repo, "https://cran.r-project.org") ||
             !identical(remote_type, "url") ||
             !identical(remote_ref, expected_ref) || nzchar(built)

--- a/scripts/write_manifest.R
+++ b/scripts/write_manifest.R
@@ -161,15 +161,20 @@ GEO_URLS <- c(
 # Source-built package DESCRIPTION files contain a wall-clock `Built` timestamp.
 # That field changes on every otherwise-identical validator run and is not package
 # identity, provenance, compatibility, or an install input. Remove it only for the
-# exact URL-pinned closure; all reproducibility-bearing fields remain hard-gated.
+# exact URL-pinned closure. rsconnect also copies DESCRIPTION's symbolic `CRAN`
+# repository label into the manifest URL field for these direct URL installs;
+# Connect Cloud requires an absolute repository URL there. Canonicalize that field
+# to the same CRAN origin while retaining each exact tarball in RemotePkgRef.
 canonical <- jsonlite::fromJSON("manifest.json", simplifyVector = FALSE)
 for (pkg in names(GEO_PINS)) {
-  if (!is.null(canonical$packages[[pkg]]$description))
+  if (!is.null(canonical$packages[[pkg]]$description)) {
     canonical$packages[[pkg]]$description$Built <- NULL
+    canonical$packages[[pkg]]$Repository <- "https://cran.r-project.org"
+  }
 }
 jsonlite::write_json(canonical, "manifest.json", auto_unbox = TRUE, pretty = TRUE,
                      null = "null")
-cat("Canonicalized non-semantic Built timestamps for the exact URL package closure.\n")
+cat("Canonicalized URL repository fields and non-semantic Built timestamps for the exact URL package closure.\n")
 
 # Pin the R version too: a runner R bump (seen: 4.5.2 -> 4.6.0) changes the
 # whole build image and can invalidate binary/source assumptions on republish.
@@ -190,15 +195,17 @@ repo_by_pkg <- vapply(chk$packages, function(x) {
   if (is.null(repo) || length(repo) != 1L || is.na(repo)) "" else as.character(repo)
 }, character(1), USE.NAMES = TRUE)
 
-# Packages installed from exact `url::` CRAN tarballs truthfully record the
-# symbolic repository `CRAN` and their URL origin in DESCRIPTION remote metadata;
+# Packages installed from exact `url::` CRAN tarballs retain their exact URL origin
+# in DESCRIPTION remote metadata. The deployable manifest must use an absolute CRAN
+# repository URL because Connect treats this top-level field as a network location;
 # ordinary dependencies resolved from the dated Posit snapshot must record that
 # snapshot URL. Reject crossed lanes, blank/third values, or a URL that differs by
 # even one character from the declared build input.
 geo_repo <- repo_by_pkg[intersect(names(GEO_PINS), names(repo_by_pkg))]
 runtime_repo <- repo_by_pkg[setdiff(names(repo_by_pkg), names(GEO_PINS))]
-if (length(geo_repo) != length(GEO_PINS) || any(geo_repo != "CRAN"))
-  bad <- c(bad, sprintf("geospatial repositories=[%s] (want CRAN for exact URL installs)",
+if (length(geo_repo) != length(GEO_PINS) ||
+    any(geo_repo != "https://cran.r-project.org"))
+  bad <- c(bad, sprintf("geospatial repositories=[%s] (want absolute CRAN URL for exact URL installs)",
                        paste(unique(unname(geo_repo)), collapse = ",")))
 if (length(runtime_repo) == 0L || any(runtime_repo != RSPM_SNAPSHOT))
   bad <- c(bad, sprintf("ordinary package repositories=[%s] (want dated snapshot %s)",

--- a/scripts/write_manifest.R
+++ b/scripts/write_manifest.R
@@ -161,20 +161,22 @@ GEO_URLS <- c(
 # Source-built package DESCRIPTION files contain a wall-clock `Built` timestamp.
 # That field changes on every otherwise-identical validator run and is not package
 # identity, provenance, compatibility, or an install input. Remove it only for the
-# exact URL-pinned closure. rsconnect also copies DESCRIPTION's symbolic `CRAN`
-# repository label into the manifest URL field for these direct URL installs;
-# Connect Cloud requires an absolute repository URL there. Canonicalize that field
-# to the same CRAN origin while retaining each exact tarball in RemotePkgRef.
+# exact URL-pinned closure. rsconnect also represents these direct installs as a URL
+# source with DESCRIPTION's symbolic `CRAN` repository label. Connect Cloud requires
+# the deployable CRAN lane plus an absolute repository URL so it can resolve current
+# and archived versions. Canonicalize those two top-level fields while retaining each
+# exact installation tarball in RemotePkgRef.
 canonical <- jsonlite::fromJSON("manifest.json", simplifyVector = FALSE)
 for (pkg in names(GEO_PINS)) {
   if (!is.null(canonical$packages[[pkg]]$description)) {
     canonical$packages[[pkg]]$description$Built <- NULL
+    canonical$packages[[pkg]]$Source <- "CRAN"
     canonical$packages[[pkg]]$Repository <- "https://cran.r-project.org"
   }
 }
 jsonlite::write_json(canonical, "manifest.json", auto_unbox = TRUE, pretty = TRUE,
                      null = "null")
-cat("Canonicalized URL repository fields and non-semantic Built timestamps for the exact URL package closure.\n")
+cat("Canonicalized the CRAN deployment lane and non-semantic Built timestamps for the exact URL package closure.\n")
 
 # Pin the R version too: a runner R bump (seen: 4.5.2 -> 4.6.0) changes the
 # whole build image and can invalidate binary/source assumptions on republish.
@@ -196,8 +198,9 @@ repo_by_pkg <- vapply(chk$packages, function(x) {
 }, character(1), USE.NAMES = TRUE)
 
 # Packages installed from exact `url::` CRAN tarballs retain their exact URL origin
-# in DESCRIPTION remote metadata. The deployable manifest must use an absolute CRAN
-# repository URL because Connect treats this top-level field as a network location;
+# in DESCRIPTION remote metadata. The deployable manifest must use the CRAN source
+# lane and an absolute CRAN repository URL because Connect uses those top-level fields
+# to select current/archive resolution and a network location;
 # ordinary dependencies resolved from the dated Posit snapshot must record that
 # snapshot URL. Reject crossed lanes, blank/third values, or a URL that differs by
 # even one character from the declared build input.
@@ -225,7 +228,7 @@ for (pkg in names(GEO_PINS)) {
   remote_ref <- as.character(chk$packages[[pkg]]$description$RemotePkgRef %||% "")
   built <- as.character(chk$packages[[pkg]]$description$Built %||% "")
   expected_ref <- paste0("url::", unname(GEO_URLS[[pkg]]))
-  if (!identical(source, "URL") || !identical(remote_type, "url") ||
+  if (!identical(source, "CRAN") || !identical(remote_type, "url") ||
       !identical(remote_ref, expected_ref) || nzchar(built))
     bad <- c(bad, sprintf(
       "%s origin Source=%s RemoteType=%s RemotePkgRef=%s Built=%s (want exact %s and no non-semantic build timestamp)",


### PR DESCRIPTION
## What changed

- canonicalize the eight exact URL-pinned geospatial packages to the deployable `Source: CRAN` lane with an absolute `https://cran.r-project.org` repository location
- preserve and hard-gate each exact tarball in `RemotePkgRef`
- make both the writer and independent bundle verifier enforce the deployable shape
- record the production failure and promote the network-contract lesson to the Driver handoff package

## Root cause

PR #73 passed package identity, origin, bundle, checksum, and offline validation, but its URL-installed package records carried `Source: URL` plus DESCRIPTION's symbolic `CRAN` label in the top-level fields Connect uses for current/archive resolution and the repository network location. Republish of merged commit `6df138c` therefore failed with an unsupported empty protocol while resolving `wk`.

## Impact

This is a focused release correction. Application logic, bundled data, scientific outputs, and the Driver decision remain unchanged. Exact URL installation provenance remains in `RemoteType`/`RemotePkgRef`; the canonical deployable manifest SHA-256 becomes `e619343d1d6404f52260481ec611ccbd1c9f5cd349657c0799f6d535a7bc0b11`.

## Validation

- JSON shape: R 4.5.2, 91 packages, 117 files
- all eight URL-installed packages use the CRAN deployment lane and absolute repository URL while retaining exact `url::https://cran.r-project.org/...` refs
- `git diff --check`
- shell syntax checks
- full pinned R/package/science/bundle/offline equality validation required in GitHub Actions before merge
