### PR TITLE
Fix Shiny message handler registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
           node --check www/app.js
           node --check www/pincards.js
           node --check www/confirm.js
+          node scripts/check_custom_message_handlers.mjs
           bash -n scripts/post_deploy_smoke.sh
 
       - name: Run scientific helper contracts

--- a/docs/BUILD-TEST-HANDOFF.md
+++ b/docs/BUILD-TEST-HANDOFF.md
@@ -487,3 +487,33 @@ Driver implication, and next action.
   through review, republish the resulting `main`, and rerun semantic health. Do not
   close issue #74 or promote the production receipt until the public app exposes its
   semantic ready marker.
+
+### 2026-07-18 15:13 MST - production restored; final console contract follow-up
+
+- **Merged/runtime evidence:** corrective PR #75 passed Actions run `29662807227`,
+  job `88128209497`, on exact head
+  `ff55d6bccdbb7f2c11d5c2bea8b066ae818515f6` and merged to `main` as
+  `9f86b13e65d333b1f911a880ab987b5b37f48a72`. Connect republished that exact
+  commit at 15:08 MST. The public app exposed
+  `ddl-app-ready=small-mammal-tracker-v1`, and the JORN exploration funnel loaded
+  6,093 captures, 2,252 individuals, 21 species, 31,584 reviewed trap-nights, and
+  the complete Overview navigation without a Startup Error.
+- **Pages evidence:** the public cover rendered the expected Small Mammal title,
+  live/repository controls, all nine companion links, exact 46-site/145-species
+  framing, and the reviewed `og-image.png` social reference.
+- **Final browser finding:** the console contained one first-party Shiny 1.14 error,
+  `handler must be a function that takes one argument.` Four no-payload custom
+  handlers used zero-argument functions. This can make counter, loading-overlay,
+  map-refit, and QC-reveal registration brittle even though the tested JORN flow
+  succeeded. Five bootstrap-datepicker language deprecation warnings are upstream
+  dependency noise, not application failures.
+- **Focused repair:** every one of the six custom message handlers now accepts
+  exactly one payload argument. A new static contract enumerates all six handlers
+  across `app.js` and `pincards.js`, fails on zero/multiple parameters or inventory
+  drift, and runs in CI after JavaScript parsing.
+- **Artifact boundary:** `app.js` and `pincards.js` are manifest-tracked runtime
+  files, so this follow-up must obtain and promote a fresh validator-generated
+  manifest before merge. No hand-authored manifest checksum is allowed.
+- **Next action:** publish the focused console-contract branch, promote only its
+  validated manifest artifact, require an exact-head green run, merge, republish,
+  and repeat semantic marker, interaction, and first-party-console verification.

--- a/docs/BUILD-TEST-HANDOFF.md
+++ b/docs/BUILD-TEST-HANDOFF.md
@@ -514,6 +514,14 @@ Driver implication, and next action.
 - **Artifact boundary:** `app.js` and `pincards.js` are manifest-tracked runtime
   files, so this follow-up must obtain and promote a fresh validator-generated
   manifest before merge. No hand-authored manifest checksum is allowed.
+- **Validated artifact:** PR #76 run `29663094833`, job `88128953998`, passed the
+  handler inventory, complete pinned dependency/runtime/science/bundle/checksum and
+  offline ladder, uploaded validated artifact
+  `small-mammal-manifest-254517e3b071d71a947638a6f7f4beebe11cb1a8`, and stopped
+  only at designed committed-manifest equality. The candidate differs from the
+  previous manifest only in exact MD5 values for `www/app.js` and
+  `www/pincards.js`; SHA-256
+  `f6c4a5ff74053b95e22fac7394f1930d2fe2329663737031b1c32f7a1f70bc54`.
 - **Next action:** publish the focused console-contract branch, promote only its
   validated manifest artifact, require an exact-head green run, merge, republish,
   and repeat semantic marker, interaction, and first-party-console verification.

--- a/docs/DRIVER-KNOWLEDGE-PACKAGE.md
+++ b/docs/DRIVER-KNOWLEDGE-PACKAGE.md
@@ -26,7 +26,7 @@ ledger because this file cannot self-pin a future merge commit.
   wall-clock URL-package `Built` timestamps removed and their top-level deployment
   lane normalized to `Source: CRAN` plus the absolute `https://cran.r-project.org`
   origin Connect requires; SHA-256
-  `e619343d1d6404f52260481ec611ccbd1c9f5cd349657c0799f6d535a7bc0b11`
+  `f6c4a5ff74053b95e22fac7394f1930d2fe2329663737031b1c32f7a1f70bc54`
 - Bundle/index contract: 46/46 expected site bundles loaded with rows and the
   physical-effort schema; national index row counts are 46/604/604; 145 species.
 

--- a/manifest.json
+++ b/manifest.json
@@ -3411,7 +3411,7 @@
       "checksum": "db1f5cf3469e11da3f383bf759bec9a5"
     },
     "www/app.js": {
-      "checksum": "a0d3a3cc5c322974704d17b3c3319df3"
+      "checksum": "b2d4f27f0935a7a73a145499ef37b622"
     },
     "www/confirm.js": {
       "checksum": "4746f2c20f51574be644c763d2a4ed48"
@@ -3420,7 +3420,7 @@
       "checksum": "7d5d665f92c09858439458678bc879a4"
     },
     "www/pincards.js": {
-      "checksum": "a05d004f1cd3d3ba52219d76fa86941b"
+      "checksum": "00a8641e1e4ae7320ff979af9425178a"
     },
     "www/rat-57.gif": {
       "checksum": "47a1c733a34701e1c0c8d1aa288888cf"

--- a/scripts/check_custom_message_handlers.mjs
+++ b/scripts/check_custom_message_handlers.mjs
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+
+const files = ["www/app.js", "www/pincards.js"];
+const handlerPattern = /Shiny\.addCustomMessageHandler\(\s*["'][^"']+["']\s*,\s*function\s*\(([^)]*)\)/g;
+let seen = 0;
+const invalid = [];
+
+for (const file of files) {
+  const source = fs.readFileSync(file, "utf8");
+  for (const match of source.matchAll(handlerPattern)) {
+    seen += 1;
+    const params = match[1]
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean);
+    if (params.length !== 1) invalid.push(`${file}: ${match[0]}`);
+  }
+}
+
+if (seen !== 6) {
+  throw new Error(`expected 6 Shiny custom message handlers, found ${seen}`);
+}
+if (invalid.length) {
+  throw new Error(`Shiny custom message handlers must accept exactly one payload argument:\n${invalid.join("\n")}`);
+}
+
+console.log(`OK: ${seen} Shiny custom message handlers accept exactly one payload argument.`);

--- a/www/app.js
+++ b/www/app.js
@@ -336,14 +336,14 @@ function whenShinyReady(fn) {
 }
 whenShinyReady(function () {
   {
-    Shiny.addCustomMessageHandler("countUp", function () {
+    Shiny.addCustomMessageHandler("countUp", function (_msg) {
       // small delay so the freshly-rendered DOM is in place
       setTimeout(runCounters, 60);
     });
     Shiny.addCustomMessageHandler("confetti", function (msg) {
       rodentConfetti(msg && msg.big);
     });
-    Shiny.addCustomMessageHandler("loadDone", function () { smtLoadDone(); });
+    Shiny.addCustomMessageHandler("loadDone", function (_msg) { smtLoadDone(); });
     // (smtSaveSite — the localStorage write — is a top-level function the server
     //  calls via shinyjs::runjs, defined above; no custom handler needed here.
     //  The shiny:connected READ that delivers smtLastSite + smtRecents to the
@@ -362,7 +362,7 @@ whenShinyReady(function () {
     // page_fillable layout (and the relocated select-panel) needs a moment to
     // settle its width before Leaflet measures, or the map captures a half-width
     // and paints narrow. Multiple dispatches catch the settled layout.
-    Shiny.addCustomMessageHandler("kickMaps", function () {
+    Shiny.addCustomMessageHandler("kickMaps", function (_msg) {
       var kick = function () { try { window.dispatchEvent(new Event("resize")); } catch (e) {} };
       requestAnimationFrame(kick);
       [80, 250, 500, 900].forEach(function (t) { setTimeout(kick, t); });

--- a/www/pincards.js
+++ b/www/pincards.js
@@ -409,7 +409,7 @@
         // Backup path: the chip click (openChip) already scrolls client-side; the
         // server also fires this after selecting the individual. Same reliable
         // instant-scroll-to-#qcCardNode helper.
-        Shiny.addCustomMessageHandler("smtRevealQc", function () { revealQcCard(); });
+        Shiny.addCustomMessageHandler("smtRevealQc", function (_msg) { revealQcCard(); });
         return;
       }
     } catch (e) { return; }   // never let a duplicate/late registration kill binding


### PR DESCRIPTION
## What changed

- make all six Shiny custom message handlers accept exactly one payload argument
- add a static inventory/arity contract and run it in CI
- record the restored production receipt and final browser finding in the app handoff

## Root cause

Shiny 1.14 reports `handler must be a function that takes one argument` for zero-argument custom handlers. The affected no-payload handlers drive counters, loading-overlay cleanup, map refits, and QC-card reveal. The public app was healthy and the JORN funnel worked, but registration remained brittle and produced a first-party console error.

## Validation

- `node --check` for all three first-party JavaScript files
- static contract finds exactly six handlers and requires one argument for each
- `git diff --check`
- full pinned R/package/science/bundle/offline pipeline runs in CI
- the first run is expected to upload a validated manifest candidate and stop at committed-manifest equality because two manifest-tracked JavaScript files changed

## Release boundary

Promote only the validator-generated manifest artifact, require a green exact-head rerun, then merge and republish. Application science and bundled data are unchanged.

## Pinned receipt

- candidate run `29663094833` passed all substantive gates and uploaded `small-mammal-manifest-254517e3b071d71a947638a6f7f4beebe11cb1a8`
- promoted manifest SHA-256: `f6c4a5ff74053b95e22fac7394f1930d2fe2329663737031b1c32f7a1f70bc54`
- exact-head run `29663236510` passed the complete ladder, including committed-manifest equality
