### PR TITLE
Close the 320px Small Mammal poster gap

### DIFF
--- a/docs/BUILD-TEST-HANDOFF.md
+++ b/docs/BUILD-TEST-HANDOFF.md
@@ -883,3 +883,36 @@ Driver implication, and next action.
 - **Production status:** manifest promotion is a reviewed candidate action only;
   `main`, Connect, Pages, scientific bundles, and Driver artifacts remain unchanged.
   Require one green equality run from the new exact PR head before merge or publish.
+
+### 2026-07-19 17:35 MST - production poster QA found a 320 px chrome wrap / root
+
+- **Published revision (PASS):** PR #82 merged as
+  `22e7b9489677c1bddfc869e2854e97b298160538`; exact-head run `29709380251` and
+  main run `29709445267` passed the complete validator. Connect deployment #120
+  successfully published exact commit `22e7b94` with R 4.5.2 in five seconds.
+- **Live functional QA (PASS):** the documentary poster, 1800 x 1350 image,
+  source boundary/scrim, concise hook and promise, CTA-to-picker anchor, Help
+  dialog, dark-mode control, JORN picker-to-dashboard funnel, loading completion,
+  and no-disconnect state all passed. Desktop and 390 px had no horizontal
+  overflow; the 390 px card and CTA retained symmetric insets, the Help target
+  was 44 px, and the CTA was 48 px tall. No legacy floating mascot remained.
+- **Narrow defect (FAIL, release-polish):** at an exact 320 x 800 viewport the
+  app was functionally usable with no horizontal overflow, but the 184 px brand
+  plus 101 px action cluster wrapped the persistent top bar to 97 px. The static
+  mock missed this because it did not reproduce bslib's 24 px body gutters or the
+  complete dark-mode control.
+- **Focused correction:** at 420 px and below, bslib page gutters contract to
+  12 px; at 390 px and below, the top bar is one non-wrapping row and the
+  redundant decorative theme glyph is hidden while the functional 44 px theme
+  control remains. The poster gains useful image/copy width at the same
+  breakpoint; the final compact wordmark scale and gaps apply only at 340 px and
+  below. CI now contracts these rules.
+- **Exact local correction check (PASS):** a 320 x 800 browser viewport with the
+  complete 29 px theme-control surrogate measured client/scroll widths 305/305,
+  12 px bslib gutters, a single-row 59 px top bar, a 44 px Help target, a 257 px
+  poster card, and a 48 px CTA with symmetric 21 px card insets.
+- **Release boundary:** this is CSS plus its static contract and evidence only;
+  no app behavior, data, science, picker ID, image, public Pages cover, or Driver
+  artifact changes. Because `www/styles.css` is manifest-tracked, a fresh pinned
+  manifest candidate and exact-head green run are still required before the
+  320 px fix may replace deployment #120.

--- a/docs/BUILD-TEST-HANDOFF.md
+++ b/docs/BUILD-TEST-HANDOFF.md
@@ -916,3 +916,29 @@ Driver implication, and next action.
   artifact changes. Because `www/styles.css` is manifest-tracked, a fresh pinned
   manifest candidate and exact-head green run are still required before the
   320 px fix may replace deployment #120.
+
+### 2026-07-19 17:52 MST - 320 px manifest candidate promoted / root
+
+- **Exact source revision:** PR #83 head
+  `517482fa4751bbe45d1fd413fdfb739e6a56df99`; GitHub evaluated immutable PR merge
+  revision `64e026f1b07dd0fa11b997059e47bcc2234c2c2d` in run `29709950504`, job
+  `88252416500`.
+- **Pinned candidate evidence (PASS):** R 4.5.2 setup, deterministic OpenBLAS,
+  source/static parsing, scientific helper contracts, exact bundle/index/file
+  verification, and complete offline app source all passed. The validated
+  manifest uploaded successfully; only the designed equality checkpoint failed
+  because the repository still contained the pre-fix stylesheet checksum.
+- **Artifact receipt:** promoted only
+  `small-mammal-manifest-64e026f1b07dd0fa11b997059e47bcc2234c2c2d/manifest.json`;
+  manifest SHA-256 is
+  `90c1366fcd51c507cb786a45a60dd59607a6980f97fc2e4d2e21b29af326d28e` and the
+  artifact archive digest reported by GitHub is
+  `sha256:1fc493a8a7d0a555a59f7df3123fd43447b9e1c06a392c71140a29f0f1692e22`.
+  Semantic comparison found identical top-level metadata, 91-package closure,
+  and 118-file inventory; the sole change is `www/styles.css` MD5 from
+  `3c7622a4cc3ae6baa12d34ca598f407e` to
+  `1f7eeeecf91ef0e805a2df6318c9dcfe`. All 118 manifest checksums independently
+  match the exact branch files.
+- **Production status:** this promotion changes no app behavior, science, data,
+  photograph, Pages cover, Connect deployment, or Driver artifact. Require an
+  exact-head green run before merge and republish.

--- a/manifest.json
+++ b/manifest.json
@@ -3435,7 +3435,7 @@
       "checksum": "03caa0fdc9353ecf3495715d7e5f11f5"
     },
     "www/styles.css": {
-      "checksum": "3c7622a4cc3ae6baa12d34ca598f407e"
+      "checksum": "1f7eeeecf91ef0e805a2df6318c9dcfe"
     },
     "www/vendor/confetti-1.9.2.browser.min.js": {
       "checksum": "9ffc3c59368462a9486359dfc5ed6ba8"

--- a/scripts/check_in_app_landing.mjs
+++ b/scripts/check_in_app_landing.mjs
@@ -53,6 +53,9 @@ requireContract(/\.smt-poster-cta\s*\{[\s\S]{0,240}gap:\s*\.35em[\s\S]{0,80}box-
 requireContract(/\.smt-poster-photo figcaption\s*\{[\s\S]{0,320}color:\s*#fffef9[\s\S]{0,80}background:\s*rgba\(17, 19, 15, \.9\)/.test(css), "photo credit lost its opaque text or dark contrast scrim");
 requireContract(css.includes("@media (max-width: 760px)") && css.includes("@media (max-width: 420px)"), "responsive poster breakpoints are missing");
 requireContract(/@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.smt-poster-cta\s*\{\s*transition:\s*none/.test(css), "poster CTA lacks reduced-motion handling");
+requireContract(/@media \(max-width: 420px\)[\s\S]{0,120}body\.bslib-page-fill\s*\{[^}]*padding-right:\s*12px;[^}]*padding-left:\s*12px/.test(css), "narrow mobile page gutters drifted");
+requireContract(/@media \(max-width: 390px\)[\s\S]{0,120}\.top-bar\s*\{[^}]*flex-wrap:\s*nowrap/.test(css) && /\.top-bar \.tb-theme-lab\s*\{\s*display:\s*none/.test(css), "320px top bar can wrap or retain the redundant theme label");
+requireContract(/@media \(max-width: 340px\)[\s\S]{0,180}\.top-bar-brand \.tb-title\s*\{\s*font-size:\s*11\.5px/.test(css), "very-narrow wordmark scale drifted");
 
 requireContract(existsSync(asset), `missing runtime image ${asset}`);
 requireContract(sha256(asset) === "e9d0158ac56f95437f0958c5aa4037701c95f2b616e87bb54440ab08e3a50f55", "runtime documentary derivative hash drifted");

--- a/www/styles.css
+++ b/www/styles.css
@@ -761,6 +761,7 @@ a.recent-chip:hover, a.recent-chip:focus-visible {
 }
 
 @media (max-width: 420px) {
+  body.bslib-page-fill { padding-right: 12px; padding-left: 12px; }
   .smt-poster { border-radius: 19px; }
   .smt-poster-photo { min-height: 275px; }
   .smt-poster-copy { padding: 24px 20px 23px; }
@@ -1074,12 +1075,20 @@ a.recent-chip:hover, a.recent-chip:focus-visible {
   .top-bar-actions .tb-help { width: 44px; padding-inline: 0; justify-content: center; }
 }
 @media (max-width: 390px) {
-  .top-bar { gap: 7px; }
+  .top-bar { gap: 7px; flex-wrap: nowrap; }
   .top-bar-brand { gap: 7px; }
   .top-bar-brand .tb-mark { width: 31px; height: 31px; }
   .top-bar-brand .tb-title { font-size: 12.5px; }
   .top-bar-brand .tb-suite { display: none; }
-  .top-bar-actions { gap: 7px; }
+  .top-bar-actions { flex: none; gap: 7px; }
+  .top-bar .tb-theme-lab { display: none; }
+}
+@media (max-width: 340px) {
+  .top-bar { gap: 4px; }
+  .top-bar-brand { gap: 4px; }
+  .top-bar-brand .tb-mark { width: 30px; height: 30px; }
+  .top-bar-brand .tb-title { font-size: 11.5px; }
+  .top-bar-actions { gap: 4px; }
 }
 
 /* ---- relocated site-select panel (was the sidebar) -------------------- */


### PR DESCRIPTION
## What changed

- narrows bslib body gutters below 420px so the poster uses scarce mobile width
- keeps the persistent top bar on one row below 390px
- preserves the functional theme control while removing redundant decoration
- applies the smallest wordmark adjustment only below 340px
- extends the static contract and release handoff

## Why

Production QA of the artistic Living Poster passed desktop and 390px, then exposed a 97px two-row utility bar at an exact 320px viewport. This focused closeout keeps the cover visually intentional at the narrow boundary without changing the documentary photo, copy, picker, app behavior, or science.

## Evidence

- exact 320x800 structural viewport: client/scroll 305/305, 12px bslib gutters, one-row 59px top bar, 44px Help target, 257px poster card, and 48px CTA with symmetric insets
- validated manifest artifact from run 29709950504; manifest SHA-256 `90c1366fcd51c507cb786a45a60dd59607a6980f97fc2e4d2e21b29af326d28e`
- semantic comparison found identical package closure, metadata, and 118-file inventory; only `www/styles.css` changed
- exact-head validator run 29710106316 passed every gate, including complete offline source and committed manifest equality

## Boundary

No app behavior, data, science, picker ID, photograph, public Pages cover, or Driver artifact changed. Connect will be republished from the merge and rechecked at desktop, 390px, and 320px.
