### PR TITLE
Publish the Small Mammal Living Poster on Pages

### DIFF
--- a/docs/BUILD-TEST-HANDOFF.md
+++ b/docs/BUILD-TEST-HANDOFF.md
@@ -978,3 +978,69 @@ Driver implication, and next action.
   when the functional app still opens generically; carry the same concise promise
   into the app, verify the real deploy commit, and gate 320 px utility chrome in
   addition to the cover itself.
+
+### 2026-07-19 19:01 MST - public Pages Living Poster correction candidate / small_mammal_live_recheck
+
+- **Starting state:** fetched clean `origin/main` at documentation closeout
+  `8d650b787075bb548d17f8380060597f5a8ff7f9` and created local branch
+  `agent/small-mammal-pages-living-poster`. Connect remains production deployment
+  #122 at runtime merge `bdf56b0`; GitHub Pages is configured from `main:/docs`.
+- **Observed mismatch/root cause:** the owner correctly reported that the artistic
+  public cover was not up. A cache-busted Pages response was byte-for-byte equal to
+  current `docs/index.html` (SHA-256
+  `4ca381e05d792761db77ac5fe105dd0ac69f88ef01839d276f9bda14e5d952e2`), and the
+  latest Pages build API reported `built` with no error on exact closeout merge
+  `8d650b7`. The file's last content commit was documentary V4 `37d9f60`; later
+  Living Poster PRs #82/#83 intentionally changed only the Connect landing. Connect
+  independently served the exact concise hook/promise/CTA and runtime image hash
+  `e9d0158a...`. This was a missing Pages implementation, not cache or publication
+  drift.
+- **Changed/classification:** replaced the long documentary V4 Pages experience
+  with a `product/UI` plus `suite-platform` Living Poster: one dominant real
+  Sherman-trap photograph, hook “One trap night. A whole population story.”,
+  promise “Follow tagged small mammals across years of return visits.”, and one
+  `Pick a place` CTA. Metric bands, methods blocks, repeated task cards, secondary
+  actions, and the full companion directory no longer compete above or below the
+  poster. A short below-fold Driver bridge, photo/data attribution, project links,
+  canonical/social metadata, skip link, focus states, reduced-motion behavior, and
+  52 px CTA remain. The static cover contract now enforces that concise boundary.
+- **Media/provenance:** no image bytes changed. Pages still uses the reviewed
+  4000 x 3000 USGS public-domain photograph with SHA-256
+  `b678af26331a98747eba64c382f1ee7e2e1f7c1f77baecbd81dd46622a9e950a` and the
+  independently composed 1200 x 630 social card with SHA-256
+  `b36c62094270bf1598f38c6162ea6fda1b5c607f513a3faeea4ed62819fdf19a`.
+- **Local static result (PASS):** `git diff --check`; Node parse and execution of
+  `scripts/check_cover.mjs`; the unchanged in-app poster contract; all six custom
+  message-handler arities; `node --check www/app.js`; safe CI YAML parse; shell
+  syntax; exact local HTTP byte serving; and photo/social hash/dimension gates
+  passed. The candidate contains one H1, one main, one safe live CTA, unique IDs,
+  no insecure asset, no unsolicited fetch, and no synthetic metric/method band.
+- **Accessibility result (PASS, static):** computed contrast ratios are acid/ink
+  15.77:1, paper/ink 18.50:1, below-fold eyebrow/paper 6.12:1, bridge text/paper
+  8.13:1, footer/paper 6.84:1, muted poster copy/ink 8.88:1, and product label/ink
+  5.98:1. The skip link, visible focus, semantic landmarks/headings, meaningful
+  image alt, 52 px CTA, 44 px footer controls, reduced-motion, increased-contrast,
+  and forced-colors alternatives are present.
+- **Independent root-owner browser result (PASS, visual/layout):** the local
+  preview passed desktop, 390 px, and 320 px review with zero horizontal overflow.
+  Desktop gives the real trap dominant visual weight and preserves the exact
+  hook/promise/CTA. At 320 x 720 the photograph measured 310 x 263, the headline
+  265 x 215, and the CTA 265 x 52; the full CTA remained visible by y=683 and all
+  substantive links were at least 44 px high. The subagent backend itself exposed
+  no browser, so console, full keyboard, and screen-reader interaction are not
+  separately claimed. No R/runtime, scientific fixture, manifest, Connect
+  interaction, or deployment result is required or claimed because only Pages
+  HTML and its static test changed.
+- **Failures/cleanup:** the first Ruby YAML probe omitted `require "date"` and was
+  rerun successfully with the class loaded. An old system HTML4 `tidy`/libxml
+  parser rejected standard HTML5 landmarks (`nav`, `main`, `section`, `figure`), so
+  it is not used as evidence. No generated asset, temporary repository file, or
+  production state was created.
+- **Ownership/status/Driver implication:** current working-tree edits to
+  `docs/index.html`, `scripts/check_cover.mjs`, and this evidence entry belong to
+  this focused candidate. They are uncommitted and unpublished. Driver implication
+  is **NONE / NO DRIVER BYTE CHANGE**; only the previously accepted artistic-poster
+  suite pattern is corrected.
+- **Next action:** commit/push the focused Pages branch, require exact-head CI,
+  merge intentionally, and bind the resulting Pages build plus cache-busted public
+  desktop/390/320 response before calling the dual-surface release complete.

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,6 +8,7 @@
   <meta name="theme-color" content="#11130f">
   <meta name="color-scheme" content="dark">
 
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='32' fill='%23d8fa55'/%3E%3Cpath d='M14 39V25h9l6 7 6-7h15v14H39V30l-10 11-10-11v9z' fill='%2311130f'/%3E%3C/svg%3E">
   <link rel="canonical" href="https://tgilbert14.github.io/NEON-Small-Mammal-Tracker-App/">
   <link rel="preload" as="image" href="assets/pacific-pocket-mouse-sherman-trap-usgs.jpg" fetchpriority="high">
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,774 +2,583 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <title>NEON Small Mammal Tracker · Desert Data Labs</title>
-  <meta name="description" content="Follow tagged small mammals from a single trap event to an effort-aware population signal across 46 NEON research sites.">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>NEON Small Mammal Tracker — Follow a tagged animal</title>
+  <meta name="description" content="Follow tagged small mammals across years of return visits in an interactive NEON data explorer.">
   <meta name="theme-color" content="#11130f">
+  <meta name="color-scheme" content="dark">
+
   <link rel="canonical" href="https://tgilbert14.github.io/NEON-Small-Mammal-Tracker-App/">
+  <link rel="preload" as="image" href="assets/pacific-pocket-mouse-sherman-trap-usgs.jpg" fetchpriority="high">
 
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://tgilbert14.github.io/NEON-Small-Mammal-Tracker-App/">
+  <meta property="og:site_name" content="NEON Explorer Suite">
   <meta property="og:title" content="One trap night. A whole population story.">
-  <meta property="og:description" content="Explore 178,216 reviewed capture records, 93,169 tagged animals, and the field evidence behind every population signal.">
+  <meta property="og:description" content="Follow tagged small mammals across years of return visits.">
+  <meta property="og:url" content="https://tgilbert14.github.io/NEON-Small-Mammal-Tracker-App/">
   <meta property="og:image" content="https://tgilbert14.github.io/NEON-Small-Mammal-Tracker-App/og-image.jpg">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
-  <meta property="og:image:alt" content="A Pacific pocket mouse emerges from a Sherman live trap beside the title One trap night. A whole population story.">
+  <meta property="og:image:alt" content="A Pacific pocket mouse leaves a Sherman live trap beside the words One trap night. A whole population story.">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="NEON Small Mammal Tracker">
-  <meta name="twitter:description" content="From one field encounter to an honest population signal.">
+  <meta name="twitter:title" content="One trap night. A whole population story.">
+  <meta name="twitter:description" content="Follow tagged small mammals across years of return visits.">
   <meta name="twitter:image" content="https://tgilbert14.github.io/NEON-Small-Mammal-Tracker-App/og-image.jpg">
-  <meta name="twitter:image:alt" content="A Pacific pocket mouse emerges from a Sherman live trap beside the title One trap night. A whole population story.">
+  <meta name="twitter:image:alt" content="A Pacific pocket mouse leaves a Sherman live trap beside the words One trap night. A whole population story.">
 
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "SoftwareApplication",
+    "@type": "WebApplication",
     "name": "NEON Small Mammal Tracker",
+    "description": "Follow tagged small mammals across years of return visits.",
     "applicationCategory": "EducationalApplication",
-    "operatingSystem": "Web",
-    "url": "https://tgilbert14.github.io/NEON-Small-Mammal-Tracker-App/",
-    "codeRepository": "https://github.com/tgilbert14/NEON-Small-Mammal-Tracker-App",
-    "isBasedOn": "https://data.neonscience.org/data-products/DP1.10072.001",
-    "author": {"@type": "Organization", "name": "Desert Data Labs"}
+    "operatingSystem": "Any",
+    "isAccessibleForFree": true,
+    "url": "https://019ec337-7100-317e-5052-c3bf32ffcb79.share.connect.posit.cloud/",
+    "codeRepository": "https://github.com/tgilbert14/NEON-Small-Mammal-Tracker-App"
   }
   </script>
 
   <style>
     :root {
-      color-scheme: light dark;
       --ink: #11130f;
-      --forest: #183d30;
-      --forest-deep: #0d2b22;
-      --field: #d8fa55;
-      --field-soft: #e9fca4;
-      --paper: #f1eee5;
-      --paper-bright: #fbfaf5;
-      --clay: #d36545;
-      --sky: #a8d7e8;
-      --white: #fffef9;
-      --muted: #5f645d;
-      --line: rgba(17, 19, 15, .18);
-      --night-line: rgba(255, 254, 249, .18);
-      --wrap: min(1220px, calc(100% - 48px));
-      --radius: 24px;
-      --shadow: 0 28px 80px rgba(12, 23, 16, .18);
+      --ink-soft: #1a1d17;
+      --paper: #fffef9;
+      --acid: #d8fa55;
+      --acid-soft: #e9fca4;
+      --sand: #e8d7b2;
+      --muted: rgba(255, 254, 249, .68);
+      --line: rgba(255, 254, 249, .16);
+      --shell: 1280px;
+      --ease: cubic-bezier(.2, .75, .25, 1);
     }
 
     *, *::before, *::after { box-sizing: border-box; }
     html { scroll-behavior: smooth; background: var(--ink); }
     body {
       margin: 0;
-      overflow-x: hidden;
-      color: var(--ink);
-      background: var(--paper);
+      color: var(--paper);
+      background: var(--ink);
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      font-size: 16px;
-      line-height: 1.55;
       -webkit-font-smoothing: antialiased;
       text-rendering: optimizeLegibility;
     }
-    img { display: block; max-width: 100%; }
-    figure { margin: 0; }
-    a { color: inherit; text-decoration: none; }
-    h1, h2, h3, p { margin-top: 0; }
-    h1, h2, h3 { line-height: .98; letter-spacing: -.055em; text-wrap: balance; }
-    p { text-wrap: pretty; }
-    [id] { scroll-margin-top: 88px; }
-    :focus-visible { outline: 3px solid var(--field); outline-offset: 4px; }
+    img { max-width: 100%; }
+    a { color: inherit; }
 
     .skip-link {
       position: fixed;
+      z-index: 100;
       top: 10px;
       left: 10px;
-      z-index: 100;
-      padding: 11px 15px;
-      border-radius: 8px;
+      padding: 12px 16px;
       color: var(--ink);
-      background: var(--field);
-      font-weight: 900;
-      transform: translateY(-150%);
-      transition: transform .15s ease;
+      background: var(--acid);
+      border-radius: 999px;
+      font-weight: 850;
+      text-decoration: none;
+      transform: translateY(-180%);
+      transition: transform .18s ease;
     }
     .skip-link:focus { transform: translateY(0); }
-    .shell { width: var(--wrap); margin-inline: auto; }
 
-    .site-nav {
+    .topline {
       position: absolute;
-      inset: 0 0 auto;
       z-index: 20;
-      color: var(--white);
-      border-bottom: 1px solid var(--night-line);
-      background: rgba(17, 19, 15, .82);
-      backdrop-filter: blur(16px);
-    }
-    .nav-inner {
-      width: var(--wrap);
-      min-height: 76px;
-      margin-inline: auto;
+      top: 0;
+      left: 0;
+      width: 44%;
+      min-height: 94px;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 28px;
+      gap: 24px;
+      padding: 26px clamp(24px, 4vw, 64px);
     }
     .brand {
       min-height: 44px;
       display: inline-flex;
       align-items: center;
-      gap: 12px;
-      font-size: .98rem;
-      font-weight: 900;
-      letter-spacing: -.02em;
+      gap: 11px;
+      color: var(--paper);
+      text-decoration: none;
     }
     .brand-mark {
-      width: 35px;
-      height: 35px;
+      width: 40px;
+      height: 40px;
       display: grid;
       place-items: center;
-      border: 1px solid rgba(255,255,255,.34);
+      flex: 0 0 auto;
+      color: var(--ink);
+      background: var(--acid);
       border-radius: 50%;
-      color: var(--field);
-      font-size: .75rem;
-      letter-spacing: -.04em;
+      font-size: .68rem;
+      font-weight: 950;
+      letter-spacing: -.03em;
+      transform: rotate(-7deg);
     }
-    .brand small {
-      display: block;
-      color: rgba(255,255,255,.62);
-      font-size: .62rem;
-      font-weight: 800;
-      letter-spacing: .15em;
+    .brand-copy {
+      display: grid;
+      gap: 2px;
+      font-size: .72rem;
+      font-weight: 850;
+      line-height: 1.05;
+      letter-spacing: .13em;
       text-transform: uppercase;
     }
-    .nav-links { display: flex; align-items: center; gap: 4px; }
-    .nav-links a {
-      min-height: 44px;
-      display: inline-flex;
-      align-items: center;
-      padding: 0 12px;
-      color: rgba(255,255,255,.72);
-      font-size: .88rem;
-      font-weight: 750;
+    .brand-copy small {
+      color: var(--muted);
+      font-size: .58rem;
+      font-weight: 700;
+      letter-spacing: .11em;
     }
-    .nav-links a:hover { color: var(--white); }
-    .nav-links .nav-open {
-      min-height: 44px;
-      margin-left: 7px;
-      padding: 0 18px;
-      border-radius: 999px;
-      color: var(--ink);
-      background: var(--field);
-      font-weight: 900;
-      white-space: nowrap;
+    .product-name {
+      color: rgba(255, 254, 249, .54);
+      font-size: .67rem;
+      font-weight: 800;
+      letter-spacing: .12em;
+      text-align: right;
+      text-transform: uppercase;
     }
 
-    .hero {
-      min-height: 830px;
+    .poster {
+      position: relative;
+      min-height: 100svh;
       display: grid;
-      grid-template-columns: minmax(0, 47%) minmax(0, 53%);
-      color: var(--white);
+      grid-template-columns: 44% 56%;
+      overflow: hidden;
+      isolation: isolate;
       background: var(--ink);
     }
-    .hero-copy {
+    .poster::after {
+      content: "";
+      position: absolute;
+      z-index: 8;
+      top: 0;
+      bottom: 0;
+      left: calc(44% - 3px);
+      width: 6px;
+      background: var(--acid);
+      pointer-events: none;
+    }
+
+    .poster-copy {
+      position: relative;
+      z-index: 3;
       min-width: 0;
-      padding: 150px max(48px, calc((100vw - 1220px) / 2 + 24px)) 52px max(24px, calc((100vw - 1220px) / 2));
+      min-height: 100svh;
       display: flex;
       flex-direction: column;
       justify-content: center;
+      align-items: flex-start;
+      padding: 132px clamp(28px, 5.25vw, 84px) 64px clamp(28px, 5.25vw, 84px);
+      overflow: hidden;
+      background:
+        radial-gradient(circle at 7% 88%, rgba(216, 250, 85, .14) 0 12%, transparent 12.4%),
+        radial-gradient(circle at 7% 88%, transparent 0 20%, rgba(216, 250, 85, .075) 20.3% 20.8%, transparent 21.1%),
+        linear-gradient(145deg, #161913 0%, var(--ink) 48%, #0c0e0b 100%);
     }
-    .kicker {
+    .poster-copy::before {
+      content: "";
+      position: absolute;
+      z-index: -1;
+      top: 16%;
+      right: -34%;
+      width: 76%;
+      aspect-ratio: 1;
+      border: 1px solid rgba(255, 254, 249, .07);
+      border-radius: 50%;
+      box-shadow: 0 0 0 58px rgba(255, 254, 249, .018), 0 0 0 116px rgba(255, 254, 249, .012);
+    }
+    .poster-kicker {
       display: inline-flex;
       align-items: center;
       gap: 10px;
-      margin-bottom: 24px;
-      color: var(--field);
-      font-size: .72rem;
+      margin: 0 0 26px;
+      color: var(--acid);
+      font-size: .68rem;
+      font-weight: 900;
+      letter-spacing: .2em;
+      text-transform: uppercase;
+    }
+    .poster-kicker::before {
+      content: "";
+      width: 30px;
+      height: 3px;
+      background: currentColor;
+    }
+    .poster h1 {
+      max-width: 720px;
+      margin: 0;
+      color: var(--paper);
+      font-size: clamp(4.35rem, 7.1vw, 8.5rem);
+      font-weight: 900;
+      line-height: .82;
+      letter-spacing: -.075em;
+      text-wrap: balance;
+    }
+    .poster h1 span { display: block; }
+    .poster h1 em {
+      display: inline;
+      color: var(--acid);
+      font-style: normal;
+    }
+    .poster-promise {
+      max-width: 430px;
+      margin: 32px 0 0;
+      color: var(--muted);
+      font-size: clamp(1rem, 1.35vw, 1.22rem);
+      line-height: 1.5;
+    }
+    .poster-cta {
+      min-height: 52px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 16px;
+      margin-top: 30px;
+      padding: 0 8px 0 24px;
+      color: var(--ink);
+      background: var(--acid);
+      border: 2px solid var(--acid);
+      border-radius: 999px;
+      box-shadow: 0 14px 34px rgba(216, 250, 85, .14);
+      font-size: .88rem;
+      font-weight: 900;
+      text-decoration: none;
+      transition: transform .18s var(--ease), background .18s ease, box-shadow .18s ease;
+    }
+    .poster-cta-icon {
+      width: 38px;
+      height: 38px;
+      display: grid;
+      place-items: center;
+      flex: 0 0 auto;
+      color: var(--paper);
+      background: var(--ink);
+      border-radius: 50%;
+      font-size: 1.15rem;
+      line-height: 1;
+      transition: transform .18s var(--ease);
+    }
+    .poster-cta:hover {
+      color: var(--ink);
+      background: var(--acid-soft);
+      box-shadow: 0 18px 42px rgba(216, 250, 85, .2);
+      transform: translateY(-3px);
+    }
+    .poster-cta:hover .poster-cta-icon { transform: translateX(3px); }
+
+    .poster-photo {
+      position: relative;
+      min-width: 0;
+      min-height: 100svh;
+      margin: 0;
+      overflow: hidden;
+      background: #5f5b4e;
+    }
+    .poster-photo::before {
+      content: "";
+      position: absolute;
+      z-index: 2;
+      inset: 0;
+      background:
+        linear-gradient(90deg, rgba(17, 19, 15, .33), transparent 18%),
+        linear-gradient(0deg, rgba(17, 19, 15, .72), transparent 28%),
+        linear-gradient(180deg, rgba(17, 19, 15, .28), transparent 18%);
+      pointer-events: none;
+    }
+    .poster-photo::after {
+      content: "";
+      position: absolute;
+      z-index: 3;
+      inset: 14px;
+      border: 1px solid rgba(255, 254, 249, .32);
+      pointer-events: none;
+    }
+    .poster-photo img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+      object-position: 100% 50%;
+      filter: saturate(.82) contrast(1.06) brightness(.92);
+      transform: scale(1.015);
+    }
+    .poster-photo figcaption {
+      position: absolute;
+      z-index: 4;
+      right: 30px;
+      bottom: 27px;
+      left: 30px;
+      color: rgba(255, 254, 249, .88);
+      font-size: .67rem;
+      font-weight: 700;
+      line-height: 1.35;
+      letter-spacing: .035em;
+      text-align: right;
+      text-shadow: 0 2px 14px rgba(0, 0, 0, .9);
+    }
+
+    .suite-bridge {
+      display: grid;
+      grid-template-columns: minmax(0, 1.35fr) minmax(260px, .65fr);
+      gap: clamp(38px, 8vw, 120px);
+      align-items: end;
+      max-width: var(--shell);
+      margin: 0 auto;
+      padding: clamp(72px, 10vw, 132px) clamp(24px, 5vw, 70px);
+      color: var(--ink);
+      background: var(--paper);
+    }
+    .bridge-wrap { background: var(--paper); }
+    .suite-bridge .eyebrow {
+      display: block;
+      margin-bottom: 16px;
+      color: #59672a;
+      font-size: .68rem;
       font-weight: 900;
       letter-spacing: .18em;
       text-transform: uppercase;
     }
-    .kicker::before { content: ""; width: 30px; height: 2px; background: currentColor; }
-    .hero h1 {
+    .suite-bridge h2 {
       max-width: 760px;
-      margin-bottom: 26px;
-      font-size: clamp(3.9rem, 6.2vw, 6.7rem);
-      letter-spacing: -.075em;
+      margin: 0;
+      color: var(--ink);
+      font-size: clamp(2.3rem, 5vw, 5.2rem);
+      font-weight: 900;
+      line-height: .95;
+      letter-spacing: -.06em;
+      text-wrap: balance;
     }
-    .hero h1 em { color: var(--field); font-style: normal; }
-    .hero-lede {
-      max-width: 590px;
-      margin-bottom: 31px;
-      color: rgba(255,255,255,.75);
-      font-size: clamp(1.05rem, 1.45vw, 1.24rem);
-      line-height: 1.55;
+    .bridge-note {
+      margin: 0;
+      color: #4d5049;
+      font-size: 1rem;
+      line-height: 1.65;
     }
-    .hero-lede strong { color: var(--white); }
-    .actions { display: flex; flex-wrap: wrap; gap: 11px; align-items: center; }
-    .button {
-      min-height: 50px;
+    .bridge-link {
+      min-height: 48px;
       display: inline-flex;
       align-items: center;
-      justify-content: center;
       gap: 12px;
-      padding: 0 21px;
-      border: 1px solid transparent;
-      border-radius: 999px;
-      font-size: .94rem;
-      font-weight: 900;
-      transition: transform .18s ease, background .18s ease;
-    }
-    .button:hover { transform: translateY(-2px); }
-    .button.primary { color: var(--ink); background: var(--field); }
-    .button.secondary { color: var(--white); border-color: rgba(255,255,255,.34); background: rgba(255,255,255,.06); }
-    .button .arrow { font-size: 1.15rem; }
-    .hero-note { margin: 16px 0 0; color: rgba(255,255,255,.47); font-size: .79rem; }
-
-    .hero-facts {
-      margin: auto 0 0;
-      padding: 31px 0 0;
-      display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 18px;
-      border-top: 1px solid var(--night-line);
-    }
-    .hero-facts strong { display: block; margin-bottom: 1px; font-size: 1.2rem; letter-spacing: -.04em; }
-    .hero-facts span { color: rgba(255,255,255,.54); font-size: .74rem; }
-
-    .hero-photo {
-      position: relative;
-      min-height: 830px;
-      overflow: hidden;
-      background: #504d40;
-    }
-    .hero-photo::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-      pointer-events: none;
-      background:
-        linear-gradient(90deg, rgba(17,19,15,.38), transparent 25%),
-        linear-gradient(0deg, rgba(17,19,15,.56), transparent 24%);
-    }
-    .hero-photo img { width: 100%; height: 100%; object-fit: cover; object-position: 58% 50%; }
-    .photo-stamp {
-      position: absolute;
-      z-index: 2;
-      right: 23px;
-      bottom: 22px;
-      max-width: 290px;
-      color: rgba(255,255,255,.82);
-      font-size: .68rem;
-      line-height: 1.4;
-      text-align: right;
-    }
-    .photo-stamp strong { display: block; color: var(--white); font-size: .72rem; }
-
-    .signal-bar {
+      margin-top: 22px;
       color: var(--ink);
-      background: var(--field);
-      border-top: 1px solid var(--ink);
-      border-bottom: 1px solid var(--ink);
-    }
-    .signal-inner {
-      min-height: 58px;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 22px;
-      padding: 10px 0;
-      font-size: .72rem;
-      font-weight: 950;
-      letter-spacing: .12em;
-      text-transform: uppercase;
-    }
-    .signal-inner span { white-space: nowrap; }
-    .signal-inner b { font-size: 1rem; }
-
-    .questions { padding: 118px 0 124px; background: var(--paper-bright); }
-    .section-intro {
-      display: grid;
-      grid-template-columns: minmax(0, .72fr) minmax(320px, .28fr);
-      gap: 64px;
-      align-items: end;
-      margin-bottom: 62px;
-    }
-    .eyebrow {
-      display: block;
-      margin-bottom: 17px;
-      color: var(--forest);
-      font-size: .72rem;
-      font-weight: 950;
-      letter-spacing: .17em;
-      text-transform: uppercase;
-    }
-    .section-intro h2, .truth h2, .suite-lead h2 {
-      max-width: 920px;
-      margin-bottom: 0;
-      font-size: clamp(3rem, 6vw, 5.9rem);
-    }
-    .section-intro p { margin: 0; color: var(--muted); font-size: 1.04rem; }
-
-    .question-list { border-top: 1px solid var(--line); }
-    .question {
-      min-height: 168px;
-      display: grid;
-      grid-template-columns: 86px minmax(0, 1.1fr) minmax(260px, .55fr) 46px;
-      gap: 28px;
-      align-items: center;
-      border-bottom: 1px solid var(--line);
-      transition: background .18s ease, padding .18s ease;
-    }
-    .question:hover { padding-inline: 18px; background: var(--field-soft); }
-    .question-number { color: var(--clay); font-size: .78rem; font-weight: 950; letter-spacing: .1em; }
-    .question h3 { margin: 0; font-size: clamp(2rem, 3.6vw, 3.5rem); }
-    .question p { margin: 0; color: var(--muted); font-size: .92rem; }
-    .question-go {
-      width: 43px;
-      height: 43px;
-      display: grid;
-      place-items: center;
-      border: 1px solid var(--ink);
-      border-radius: 50%;
-      font-size: 1.18rem;
-      transition: color .18s ease, background .18s ease;
-    }
-    .question:hover .question-go { color: var(--white); background: var(--ink); }
-
-    .field-logic { padding: 120px 0; color: var(--white); background: var(--forest-deep); }
-    .logic-head {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) 330px;
-      gap: 60px;
-      align-items: end;
-      margin-bottom: 58px;
-    }
-    .logic-head .eyebrow { color: var(--field); }
-    .logic-head h2 { max-width: 850px; margin-bottom: 0; font-size: clamp(3rem, 5.8vw, 5.7rem); }
-    .logic-head p { margin: 0; color: rgba(255,255,255,.64); }
-    .logic-grid { display: grid; grid-template-columns: minmax(0, 1.22fr) minmax(380px, .78fr); gap: 26px; }
-    .trap-closeup {
-      position: relative;
-      min-height: 545px;
-      overflow: hidden;
-      border-radius: var(--radius);
-      background: #58584d;
-      box-shadow: var(--shadow);
-    }
-    .trap-closeup img { width: 100%; height: 100%; object-fit: cover; object-position: 62% 52%; }
-    .trap-closeup figcaption {
-      position: absolute;
-      inset: auto 18px 18px;
-      padding: 13px 15px;
-      border: 1px solid rgba(255,255,255,.22);
-      border-radius: 12px;
-      color: rgba(255,255,255,.76);
-      background: rgba(13,43,34,.82);
-      backdrop-filter: blur(14px);
-      font-size: .76rem;
-    }
-    .logic-steps { margin: 0; padding: 0; list-style: none; counter-reset: logic; border-top: 1px solid var(--night-line); }
-    .logic-steps li {
-      counter-increment: logic;
-      display: grid;
-      grid-template-columns: 42px 1fr;
-      gap: 17px;
-      padding: 24px 0;
-      border-bottom: 1px solid var(--night-line);
-    }
-    .logic-steps li::before {
-      content: "0" counter(logic);
-      color: var(--field);
-      font-size: .72rem;
-      font-weight: 950;
-      letter-spacing: .08em;
-    }
-    .logic-steps h3 { margin: 0 0 7px; font-size: 1.45rem; letter-spacing: -.04em; }
-    .logic-steps p { margin: 0; color: rgba(255,255,255,.62); font-size: .88rem; }
-
-    .truth { padding: 125px 0; background: var(--paper); }
-    .truth-heading { max-width: 970px; margin-bottom: 65px; }
-    .truth-heading .eyebrow { color: var(--clay); }
-    .truth-heading h2 em { color: var(--clay); font-style: normal; }
-    .measure-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border-block: 1px solid var(--line); }
-    .measure { padding: 34px 34px 37px 0; }
-    .measure + .measure { padding-left: 34px; border-left: 1px solid var(--line); }
-    .measure-code { display: block; margin-bottom: 18px; color: var(--forest); font-size: .76rem; font-weight: 950; letter-spacing: .14em; }
-    .measure h3 { margin-bottom: 12px; font-size: 1.9rem; }
-    .measure p { margin: 0; color: var(--muted); font-size: .91rem; }
-    .boundary {
-      margin-top: 58px;
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      border: 1px solid var(--ink);
-      border-radius: var(--radius);
-      overflow: hidden;
-    }
-    .boundary article { padding: 30px; }
-    .boundary article:first-child { background: var(--field); }
-    .boundary article:last-child { color: var(--white); background: var(--ink); }
-    .boundary h3 { margin-bottom: 10px; font-size: 1.5rem; }
-    .boundary p { max-width: 55ch; margin: 0; font-size: .91rem; opacity: .78; }
-
-    .receipt {
-      margin-top: 28px;
-      border: 1px solid var(--line);
-      border-radius: 18px;
-      background: rgba(255,255,255,.45);
-    }
-    .receipt summary {
-      min-height: 60px;
-      padding: 17px 20px;
-      cursor: pointer;
       font-weight: 900;
+      text-decoration-thickness: 2px;
+      text-underline-offset: 6px;
     }
-    .receipt-inner {
-      padding: 4px 20px 22px;
-      display: grid;
-      grid-template-columns: 1fr auto;
-      gap: 24px;
-      align-items: end;
-    }
-    .receipt-inner p { max-width: 72ch; margin: 0; color: var(--muted); font-size: .86rem; }
-    .receipt-links { display: flex; flex-wrap: wrap; gap: 14px; }
-    .text-link { border-bottom: 1px solid currentColor; font-size: .84rem; font-weight: 900; }
 
-    .suite { padding: 120px 0; color: var(--white); background: var(--ink); }
-    .suite-grid { display: grid; grid-template-columns: minmax(0, .75fr) minmax(480px, 1.25fr); gap: 74px; align-items: start; }
-    .suite-lead { position: sticky; top: 108px; }
-    .suite-lead .eyebrow { color: var(--field); }
-    .suite-lead h2 { margin-bottom: 24px; }
-    .suite-lead p { max-width: 48ch; margin-bottom: 29px; color: rgba(255,255,255,.62); }
-    .driver-link {
-      min-height: 74px;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 20px;
-      padding: 18px 20px;
-      border: 1px solid var(--field);
-      border-radius: 16px;
-      color: var(--ink);
-      background: var(--field);
-      font-weight: 950;
+    footer {
+      border-top: 1px solid #e7e3d8;
+      color: #585b54;
+      background: var(--paper);
     }
-    .driver-link small { display: block; margin-top: 3px; font-size: .68rem; font-weight: 850; opacity: .64; letter-spacing: .1em; text-transform: uppercase; }
-    .suite-list { margin: 0; padding: 0; list-style: none; border-top: 1px solid var(--night-line); }
-    .suite-link {
-      min-height: 67px;
-      display: grid;
-      grid-template-columns: 42px 1fr auto;
-      gap: 14px;
-      align-items: center;
-      border-bottom: 1px solid var(--night-line);
-      color: rgba(255,255,255,.74);
-      font-weight: 800;
-      transition: color .16s ease, padding .16s ease;
-    }
-    .suite-link:hover { padding-left: 9px; color: var(--white); }
-    .suite-link .num { color: rgba(255,255,255,.35); font-size: .68rem; letter-spacing: .08em; }
-    .suite-link .kind { color: rgba(255,255,255,.38); font-size: .68rem; font-weight: 850; letter-spacing: .1em; text-transform: uppercase; }
-    .suite-link.current { color: var(--ink); background: var(--field); padding-inline: 14px; }
-    .suite-link.current .num, .suite-link.current .kind { color: rgba(17,19,15,.55); }
-
-    .closing { padding: 112px 0 118px; color: var(--ink); background: var(--field); text-align: center; }
-    .closing h2 { max-width: 920px; margin: 0 auto 20px; font-size: clamp(3.2rem, 7vw, 7rem); }
-    .closing p { max-width: 630px; margin: 0 auto 30px; font-size: 1.05rem; }
-    .closing .actions { justify-content: center; }
-    .closing .button.primary { color: var(--white); background: var(--ink); }
-    .closing .button.secondary { color: var(--ink); border-color: var(--ink); background: transparent; }
-
-    footer { color: rgba(255,255,255,.62); background: var(--ink); }
     .footer-inner {
-      min-height: 84px;
+      max-width: var(--shell);
+      min-height: 92px;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 22px;
-      font-size: .74rem;
+      gap: 24px;
+      margin: 0 auto;
+      padding: 22px clamp(24px, 5vw, 70px);
+      font-size: .76rem;
+      line-height: 1.5;
     }
-    .footer-links { display: flex; flex-wrap: wrap; gap: 18px; }
-    .footer-links a:hover { color: var(--white); }
+    .footer-links {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 10px 22px;
+    }
+    .footer-links a {
+      min-height: 44px;
+      display: inline-flex;
+      align-items: center;
+      color: var(--ink);
+      font-weight: 800;
+      text-underline-offset: 4px;
+    }
+
+    :focus-visible {
+      outline: 3px solid var(--acid);
+      outline-offset: 4px;
+    }
+    .poster-cta:focus-visible {
+      outline-color: var(--paper);
+      outline-offset: 5px;
+    }
 
     @media (max-width: 980px) {
-      :root { --wrap: min(100% - 34px, 760px); }
-      .nav-links > a:not(.nav-open) { display: none; }
-      .hero { min-height: auto; grid-template-columns: 1fr; }
-      .hero-copy { min-height: 690px; padding: 126px 24px 44px max(17px, calc((100vw - 760px) / 2)); }
-      .hero-photo { min-height: 640px; }
-      .hero-photo::after { background: linear-gradient(0deg, rgba(17,19,15,.55), transparent 30%); }
-      .section-intro, .logic-head { grid-template-columns: 1fr; gap: 24px; }
-      .question { grid-template-columns: 62px minmax(0, 1fr) 42px; }
-      .question p { grid-column: 2; }
-      .question-go { grid-column: 3; grid-row: 1 / span 2; }
-      .logic-grid { grid-template-columns: 1fr; }
-      .logic-steps { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
-      .logic-steps li:nth-child(odd) { padding-right: 20px; }
-      .logic-steps li:nth-child(even) { padding-left: 20px; border-left: 1px solid var(--night-line); }
-      .suite-grid { grid-template-columns: 1fr; gap: 52px; }
-      .suite-lead { position: static; }
-      .receipt-inner { grid-template-columns: 1fr; }
+      .topline { width: 50%; }
+      .poster { grid-template-columns: 50% 50%; }
+      .poster::after { left: calc(50% - 3px); }
+      .poster h1 { font-size: clamp(3.75rem, 8.2vw, 6.6rem); }
     }
 
-    @media (max-width: 700px) {
-      :root { --wrap: calc(100% - 28px); --radius: 18px; }
-      .nav-inner { min-height: 68px; }
-      .brand { font-size: .86rem; white-space: nowrap; }
-      .brand small { display: none; }
-      .nav-links .nav-open { min-height: 44px; margin-left: 0; padding: 0 14px; font-size: .8rem; }
-      .hero-copy { min-height: 590px; padding: 108px 18px 37px; }
-      .hero h1 { max-width: 560px; font-size: clamp(3.25rem, 17vw, 5.15rem); }
-      .hero-lede { margin-bottom: 25px; font-size: 1rem; }
-      .hero .button.secondary { display: none; }
-      .hero-facts { gap: 10px; padding-top: 23px; }
-      .hero-facts strong { font-size: 1rem; }
-      .hero-facts span { font-size: .63rem; }
-      .hero-photo { min-height: 520px; order: -1; }
-      .hero-photo img { object-position: 61% 50%; }
-      .hero-photo::after { background: linear-gradient(180deg, rgba(17,19,15,.6), transparent 25%, transparent 70%, rgba(17,19,15,.58)); }
-      .photo-stamp { right: 14px; bottom: 13px; left: 14px; max-width: none; font-size: .61rem; }
-      .photo-stamp strong { font-size: .67rem; }
-      .signal-inner { justify-content: center; gap: 9px; font-size: .62rem; letter-spacing: .08em; }
-      .signal-inner span:nth-child(3), .signal-inner span:nth-child(4) { display: none; }
-      .questions, .field-logic, .truth, .suite { padding: 84px 0; }
-      .section-intro { margin-bottom: 37px; }
-      .section-intro h2, .truth h2, .suite-lead h2 { font-size: clamp(2.65rem, 13vw, 4.3rem); }
-      .question {
-        min-height: 172px;
-        grid-template-columns: 38px minmax(0, 1fr) 39px;
-        gap: 10px;
-        padding: 21px 0;
+    @media (max-width: 760px) {
+      .topline {
+        position: absolute;
+        width: 100%;
+        min-height: 62px;
+        padding: 9px 16px;
+        background: linear-gradient(180deg, rgba(17, 19, 15, .82), rgba(17, 19, 15, .18), transparent);
       }
-      .question:hover { padding-inline: 7px; }
-      .question h3 { font-size: 2rem; }
-      .question p { font-size: .82rem; }
-      .question-go { width: 38px; height: 38px; }
-      .logic-head { margin-bottom: 38px; }
-      .logic-head h2 { font-size: clamp(2.75rem, 13vw, 4.3rem); }
-      .trap-closeup { min-height: 410px; }
-      .logic-steps { grid-template-columns: 1fr; }
-      .logic-steps li:nth-child(odd), .logic-steps li:nth-child(even) { padding: 21px 0; border-left: 0; }
-      .measure-grid { grid-template-columns: 1fr; }
-      .measure, .measure + .measure { padding: 25px 0; border-left: 0; border-bottom: 1px solid var(--line); }
-      .measure:last-child { border-bottom: 0; }
-      .boundary { grid-template-columns: 1fr; }
-      .boundary article { padding: 24px; }
-      .suite-link { grid-template-columns: 32px 1fr; }
-      .suite-link .kind { display: none; }
-      .closing { padding: 85px 0 92px; }
-      .closing h2 { font-size: clamp(3.1rem, 16vw, 5.2rem); }
-      .footer-inner { padding: 25px 0; align-items: flex-start; flex-direction: column; }
+      .brand { gap: 8px; }
+      .brand-mark { width: 36px; height: 36px; font-size: .62rem; }
+      .brand-copy { font-size: .64rem; }
+      .brand-copy small { font-size: .52rem; }
+      .product-name { color: rgba(255, 254, 249, .82); font-size: .58rem; }
+
+      .poster {
+        min-height: 100svh;
+        grid-template-columns: 1fr;
+        grid-template-rows: minmax(270px, 39svh) auto;
+      }
+      .poster::after {
+        top: calc(39svh - 3px);
+        right: 0;
+        bottom: auto;
+        left: 0;
+        width: auto;
+        height: 6px;
+      }
+      .poster-photo {
+        grid-row: 1;
+        min-height: 270px;
+        height: 39svh;
+      }
+      .poster-photo img { object-position: 100% 52%; }
+      .poster-photo::before {
+        background:
+          linear-gradient(180deg, rgba(17, 19, 15, .38), transparent 30%),
+          linear-gradient(0deg, rgba(17, 19, 15, .38), transparent 24%);
+      }
+      .poster-photo::after { inset: 10px; }
+      .poster-photo figcaption {
+        right: 18px;
+        bottom: 15px;
+        left: 18px;
+        font-size: .6rem;
+      }
+      .poster-copy {
+        grid-row: 2;
+        min-height: calc(61svh + 6px);
+        justify-content: center;
+        padding: 42px clamp(22px, 8vw, 50px) 38px;
+      }
+      .poster-copy::before { top: 0; right: -28%; width: 62%; }
+      .poster-kicker { margin-bottom: 18px; font-size: .61rem; }
+      .poster h1 {
+        max-width: 610px;
+        font-size: clamp(3.35rem, 14.2vw, 6rem);
+        line-height: .86;
+      }
+      .poster-promise { margin-top: 23px; font-size: .98rem; line-height: 1.45; }
+      .poster-cta { min-height: 52px; margin-top: 22px; }
+
+      .suite-bridge { grid-template-columns: 1fr; gap: 34px; }
+      .bridge-note { max-width: 540px; }
+      .footer-inner { align-items: flex-start; flex-direction: column; gap: 2px; }
+      .footer-links { justify-content: flex-start; }
     }
 
     @media (max-width: 360px) {
-      .nav-inner { gap: 8px; }
-      .brand > span:last-child { display: none; }
-      .nav-links .nav-open { padding-inline: 12px; }
+      .topline { padding-right: 12px; padding-left: 12px; }
+      .brand-copy span { display: none; }
+      .brand-copy small { font-size: .56rem; }
+      .product-name { max-width: 122px; line-height: 1.2; }
+      .poster { grid-template-rows: minmax(250px, 36svh) auto; }
+      .poster::after { top: calc(36svh - 3px); }
+      .poster-photo { min-height: 250px; height: 36svh; }
+      .poster-copy {
+        min-height: calc(64svh + 6px);
+        padding: 34px 20px 30px;
+      }
+      .poster-kicker { margin-bottom: 16px; }
+      .poster h1 { font-size: clamp(3.05rem, 15.6vw, 3.6rem); }
+      .poster-promise { margin-top: 18px; }
+      .poster-cta { width: 100%; justify-content: space-between; margin-top: 20px; }
+      .suite-bridge { padding-right: 20px; padding-left: 20px; }
     }
 
     @media (prefers-reduced-motion: reduce) {
-      *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; }
+      html { scroll-behavior: auto; }
+      *, *::before, *::after {
+        scroll-behavior: auto !important;
+        transition-duration: .001ms !important;
+        animation-duration: .001ms !important;
+        animation-iteration-count: 1 !important;
+      }
+      .poster-cta:hover,
+      .poster-cta:hover .poster-cta-icon { transform: none; }
+    }
+
+    @media (prefers-contrast: more) {
+      .poster-promise, .product-name, .poster-photo figcaption { color: var(--paper); }
+      .poster-photo figcaption { padding: 7px 9px; background: rgba(17, 19, 15, .94); }
+      .bridge-note, footer { color: #242620; }
+    }
+
+    @media (forced-colors: active) {
+      .brand-mark, .poster-cta, .poster-cta-icon { border: 2px solid ButtonText; }
+      .poster::after { background: Highlight; }
     }
   </style>
 </head>
-<body>
-  <a class="skip-link" href="#main">Skip to the story</a>
 
-  <nav class="site-nav" aria-label="Cover navigation">
-    <div class="nav-inner">
-      <a class="brand" href="https://tgilbert14.github.io/NEON-Driver-Cascade/" aria-label="Desert Data Labs Explorer Suite home">
-        <span class="brand-mark" aria-hidden="true">DDL</span>
-        <span>Desert Data Labs<small>NEON Explorer Suite</small></span>
-      </a>
-      <div class="nav-links">
-        <a href="#questions">Ways in</a>
-        <a href="#evidence">Evidence</a>
-        <a href="#suite">The suite</a>
-        <a class="nav-open" href="https://019ec337-7100-317e-5052-c3bf32ffcb79.share.connect.posit.cloud/" target="_blank" rel="noopener">Launch tracker <span aria-hidden="true">↗</span></a>
-      </div>
-    </div>
+<body>
+  <a class="skip-link" href="#main">Skip to the poster</a>
+
+  <nav class="topline" aria-label="Cover navigation">
+    <a class="brand" href="#main" aria-label="NEON Explorer Suite, Small Mammal Tracker">
+      <span class="brand-mark" aria-hidden="true">DDL</span>
+      <span class="brand-copy"><span>Desert Data Labs</span><small>NEON Explorer Suite</small></span>
+    </a>
+    <span class="product-name" aria-current="page">Small Mammal Tracker</span>
   </nav>
 
   <main id="main">
-    <section class="hero" aria-labelledby="hero-title">
-      <div class="hero-copy">
-        <div class="kicker">NEON Small Mammal Tracker</div>
-        <h1 id="hero-title">One trap night. A whole <em>population story.</em></h1>
-        <p class="hero-lede">Meet the tagged animals inside America’s longest-running continental field observatory—and see exactly when a capture becomes <strong>evidence, an index, or an estimate.</strong></p>
-        <div class="actions">
-          <a class="button primary" href="https://019ec337-7100-317e-5052-c3bf32ffcb79.share.connect.posit.cloud/" target="_blank" rel="noopener">Follow an animal <span class="arrow" aria-hidden="true">→</span></a>
-          <a class="button secondary" href="#questions">Choose a question</a>
-        </div>
-        <p class="hero-note">Free to explore · No account required · Field definitions stay attached</p>
-        <div class="hero-facts" aria-label="Verified data scope">
-          <div><strong>46</strong><span>NEON sites</span></div>
-          <div><strong>93,169</strong><span>tagged animals</span></div>
-          <div><strong>2013–2024</strong><span>reviewed vintage</span></div>
-        </div>
+    <section class="poster" aria-labelledby="poster-title">
+      <div class="poster-copy">
+        <p class="poster-kicker">Small Mammal Tracker</p>
+        <h1 id="poster-title" aria-label="One trap night. A whole population story.">One trap night.<span>A whole <em>population story.</em></span></h1>
+        <p class="poster-promise">Follow tagged small mammals across years of return visits.</p>
+        <a class="poster-cta" href="https://019ec337-7100-317e-5052-c3bf32ffcb79.share.connect.posit.cloud/" target="_blank" rel="noopener">
+          <span>Pick a place</span><span class="poster-cta-icon" aria-hidden="true">→</span>
+        </a>
       </div>
-      <figure class="hero-photo">
-        <img src="assets/pacific-pocket-mouse-sherman-trap-usgs.jpg" alt="A Pacific pocket mouse emerges from the open door of a metal Sherman live trap on leaf-strewn ground." width="4000" height="3000">
-        <figcaption class="photo-stamp"><strong>This is real field equipment—not generated scenery.</strong>Pacific pocket mouse with Sherman live trap · Cheryl Brehme, USGS · Public domain</figcaption>
+
+      <figure class="poster-photo">
+        <img src="assets/pacific-pocket-mouse-sherman-trap-usgs.jpg" alt="A Pacific pocket mouse emerges from the open door of a large metal Sherman live trap on leaf-strewn ground." width="4000" height="3000" fetchpriority="high" decoding="async">
+        <figcaption>Pacific pocket mouse · Cheryl Brehme, USGS · Public domain</figcaption>
       </figure>
     </section>
 
-    <div class="signal-bar" aria-hidden="true">
-      <div class="shell signal-inner">
-        <span><b>Trap</b> · encounter</span>
-        <span><b>Tag</b> · identity</span>
-        <span><b>Recapture</b> · history</span>
-        <span><b>Interpret</b> · signal</span>
-      </div>
+    <div class="bridge-wrap">
+      <section class="suite-bridge" aria-labelledby="suite-title">
+        <div>
+          <span class="eyebrow">Part of the NEON Explorer Suite</span>
+          <h2 id="suite-title">One animal in a much bigger field story.</h2>
+        </div>
+        <div>
+          <p class="bridge-note">Small Mammal Tracker is one independent way into the living network.</p>
+          <a class="bridge-link" href="https://tgilbert14.github.io/NEON-Driver-Cascade/">Meet the whole suite <span aria-hidden="true">→</span></a>
+        </div>
+      </section>
     </div>
-
-    <section class="questions" id="questions" aria-labelledby="questions-title">
-      <div class="shell">
-        <div class="section-intro">
-          <div>
-            <span class="eyebrow">Start with curiosity</span>
-            <h2 id="questions-title">What do you want to know tonight?</h2>
-          </div>
-          <p>No canned tour. Pick a living question and the tracker takes you to the right evidence.</p>
-        </div>
-
-        <div class="question-list">
-          <a class="question" href="https://019ec337-7100-317e-5052-c3bf32ffcb79.share.connect.posit.cloud/" target="_blank" rel="noopener">
-            <span class="question-number">01</span>
-            <h3>Who came back?</h3>
-            <p>Open a tagged animal’s dossier and trace every recorded encounter across nights, plots, and years.</p>
-            <span class="question-go" aria-hidden="true">↗</span>
-          </a>
-          <a class="question" href="https://019ec337-7100-317e-5052-c3bf32ffcb79.share.connect.posit.cloud/" target="_blank" rel="noopener">
-            <span class="question-number">02</span>
-            <h3>Is the population changing?</h3>
-            <p>Compare catch-per-effort and minimum-known-alive; use model estimates only where the data support them.</p>
-            <span class="question-go" aria-hidden="true">↗</span>
-          </a>
-          <a class="question" href="https://019ec337-7100-317e-5052-c3bf32ffcb79.share.connect.posit.cloud/" target="_blank" rel="noopener">
-            <span class="question-number">03</span>
-            <h3>Who shares the night?</h3>
-            <p>Read the community by species, season, plot, body size, and the cadence of recapture.</p>
-            <span class="question-go" aria-hidden="true">↗</span>
-          </a>
-        </div>
-      </div>
-    </section>
-
-    <section class="field-logic" id="evidence" aria-labelledby="logic-title">
-      <div class="shell">
-        <div class="logic-head">
-          <div>
-            <span class="eyebrow">The field record, uncompressed</span>
-            <h2 id="logic-title">The trap is a measurement. Not the conclusion.</h2>
-          </div>
-          <p>The tracker keeps effort, detection, identity, and uncertainty visible so a memorable animal never becomes a misleading headline.</p>
-        </div>
-
-        <div class="logic-grid">
-          <figure class="trap-closeup">
-            <img src="assets/pacific-pocket-mouse-sherman-trap-usgs.jpg" alt="Close view of a Pacific pocket mouse at the opening of a Sherman live trap." width="4000" height="3000" loading="lazy">
-            <figcaption>Humane live traps create encounter records. Repeated, reviewed encounters create histories that can support population inference.</figcaption>
-          </figure>
-          <ol class="logic-steps">
-            <li><div><h3>Set the effort</h3><p>Trap nights supply the denominator. More sampling is not automatically more animals.</p></div></li>
-            <li><div><h3>Record the encounter</h3><p>Species, tag, body measurements, plot, date, and handling context stay connected.</p></div></li>
-            <li><div><h3>Recognize the return</h3><p>A tag turns separate captures into an individual history—without inventing movement between observations.</p></div></li>
-            <li><div><h3>Earn the inference</h3><p>Indices appear with definitions; model-based abundance is withheld when sparse data cannot carry it.</p></div></li>
-          </ol>
-        </div>
-      </div>
-    </section>
-
-    <section class="truth" aria-labelledby="truth-title">
-      <div class="shell">
-        <div class="truth-heading">
-          <span class="eyebrow">Honesty is a feature</span>
-          <h2 id="truth-title">A count is not a <em>population.</em></h2>
-        </div>
-
-        <div class="measure-grid">
-          <article class="measure">
-            <span class="measure-code">CPUE · field index</span>
-            <h3>Catch per effort</h3>
-            <p>A within-site catch-rate index tied to trap nights. Useful for comparison; not density or absolute abundance.</p>
-          </article>
-          <article class="measure">
-            <span class="measure-code">MNKA · conservative floor</span>
-            <h3>Minimum known alive</h3>
-            <p>The animals known from capture histories to have been alive in a period. A minimum, not a full census.</p>
-          </article>
-          <article class="measure">
-            <span class="measure-code">N-hat · gated estimate</span>
-            <h3>Modelled abundance</h3>
-            <p>Shown only when recapture information can support estimation. No plausible-looking number is substituted for missing evidence.</p>
-          </article>
-        </div>
-
-        <div class="boundary" aria-label="Claim boundaries">
-          <article><h3>What this can tell you</h3><p>Where and when animals were handled, which individuals returned, and how supported community or population signals vary within the reviewed record.</p></article>
-          <article><h3>What this cannot tell you</h3><p>The exact number of every animal present, unobserved movement paths, or causal ecosystem change from capture records alone.</p></article>
-        </div>
-
-        <details class="receipt">
-          <summary>Methods &amp; release receipt</summary>
-          <div class="receipt-inner">
-            <p>NEON product DP1.10072.001 · 178,216 reviewed capture/handling rows · 93,169 tagged individuals · 145 species · 46 sites · 2013–2024. Last production verification: July 18, 2026. Counts and scope are pinned to the app’s reviewed bundle and verification record.</p>
-            <div class="receipt-links">
-              <a class="text-link" href="https://data.neonscience.org/data-products/DP1.10072.001">NEON product ↗</a>
-              <a class="text-link" href="https://github.com/tgilbert14/NEON-Small-Mammal-Tracker-App/blob/main/docs/BUILD-TEST-HANDOFF.md">Release receipt ↗</a>
-              <a class="text-link" href="https://github.com/tgilbert14/NEON-Small-Mammal-Tracker-App">Source &amp; methods ↗</a>
-            </div>
-          </div>
-        </details>
-      </div>
-    </section>
-
-    <section class="suite" id="suite" aria-labelledby="suite-title">
-      <div class="shell suite-grid">
-        <div class="suite-lead">
-          <span class="eyebrow">Continue the cascade</span>
-          <h2 id="suite-title">One explorer. One honest signal.</h2>
-          <p>Small mammals are one piece of a ten-explorer evidence system. The Driver brings the suite together without pretending distinct measurements are interchangeable.</p>
-          <a class="driver-link" href="https://tgilbert14.github.io/NEON-Driver-Cascade/">
-            <span>Open the NEON Driver Cascade<small>Suite synthesis &amp; provenance</small></span><span aria-hidden="true">↗</span>
-          </a>
-        </div>
-
-        <nav aria-label="NEON Explorer Suite">
-          <ol class="suite-list">
-            <li><a class="suite-link" href="https://tgilbert14.github.io/NEON-Plant-Phenology-Explorer/"><span class="num">01</span><span>Plant Phenology</span><span class="kind">Timing</span></a></li>
-            <li><a class="suite-link" href="https://tgilbert14.github.io/NEON-Plant-Diversity/"><span class="num">02</span><span>Plant Diversity</span><span class="kind">Composition</span></a></li>
-            <li><a class="suite-link" href="https://tgilbert14.github.io/NEON-Vegetation-Structure-Explorer/"><span class="num">03</span><span>Vegetation Structure</span><span class="kind">Habitat</span></a></li>
-            <li><a class="suite-link current" aria-current="page" href="#main"><span class="num">04</span><span>Small Mammals</span><span class="kind">Consumer</span></a></li>
-            <li><a class="suite-link" href="https://tgilbert14.github.io/NEON-Ground-Beetle-Tracker/"><span class="num">05</span><span>Ground Beetles</span><span class="kind">Consumer</span></a></li>
-            <li><a class="suite-link" href="https://tgilbert14.github.io/NEON-Mosquito-Pulse/"><span class="num">06</span><span>Mosquito Pulse</span><span class="kind">Vector</span></a></li>
-            <li><a class="suite-link" href="https://tgilbert14.github.io/NEON-Breeding-Birds/"><span class="num">07</span><span>Breeding Birds</span><span class="kind">Consumer</span></a></li>
-            <li><a class="suite-link" href="https://tgilbert14.github.io/NEON-WaterChemistry-Analyte-Viewer-App/"><span class="num">08</span><span>Water Chemistry</span><span class="kind">Aquatic</span></a></li>
-            <li><a class="suite-link" href="https://tgilbert14.github.io/NEON-My-Little-Inverts/"><span class="num">09</span><span>My Little Inverts</span><span class="kind">Aquatic</span></a></li>
-          </ol>
-        </nav>
-      </div>
-    </section>
-
-    <section class="closing" aria-labelledby="closing-title">
-      <div class="shell">
-        <h2 id="closing-title">Find the animal behind the number.</h2>
-        <p>Start at a NEON site, open a tag history, and decide for yourself what the field record can support.</p>
-        <div class="actions">
-          <a class="button primary" href="https://019ec337-7100-317e-5052-c3bf32ffcb79.share.connect.posit.cloud/" target="_blank" rel="noopener">Open the live tracker <span class="arrow" aria-hidden="true">↗</span></a>
-          <a class="button secondary" href="https://github.com/tgilbert14/NEON-Small-Mammal-Tracker-App">View the evidence trail</a>
-        </div>
-      </div>
-    </section>
   </main>
 
   <footer>
-    <div class="shell footer-inner">
-      <span>Desert Data Labs · NEON Explorer Suite</span>
-      <div class="footer-links">
-        <a href="https://github.com/tgilbert14/NEON-Small-Mammal-Tracker-App">GitHub</a>
-        <a href="https://www.usgs.gov/media/images/pacific-pocket-mouse-sherman-trap">Photo: USGS public domain</a>
-        <a href="https://creativecommons.org/licenses/by/4.0/">NEON data license</a>
-      </div>
+    <div class="footer-inner">
+      <span>Independent explorer · data from NEON DP1.10072.001</span>
+      <nav class="footer-links" aria-label="Project and source links">
+        <a href="https://github.com/tgilbert14/NEON-Small-Mammal-Tracker-App">Source</a>
+        <a href="https://data.neonscience.org/data-products/DP1.10072.001">NEON data</a>
+        <a href="https://www.usgs.gov/media/images/pacific-pocket-mouse-sherman-trap">Photo source</a>
+      </nav>
     </div>
   </footer>
 </body>

--- a/scripts/check_cover.mjs
+++ b/scripts/check_cover.mjs
@@ -39,11 +39,14 @@ requireContract(count(/<main\b/gi) === 1, "must contain exactly one main landmar
 requireContract(/class="skip-link"[^>]+href="#main"/.test(html), "missing skip link");
 requireContract(/<nav[^>]+aria-label="Cover navigation"/.test(html), "navigation needs an accessible name");
 requireContract(/aria-current="page"/.test(html), "current suite product is not identified");
+requireContract(/<h1[^>]+aria-label="One trap night\. A whole population story\."/.test(html), "poster heading needs one continuous accessible name");
 requireContract(/One trap night\. A whole/.test(html) && /population story\./.test(html), "persuasive cover promise missing");
-requireContract(/Who came back\?/.test(html) && /Is the population changing\?/.test(html) && /Who shares the night\?/.test(html), "question-led entry points missing");
-requireContract(/What this can tell you/.test(html) && /What this cannot tell you/.test(html), "claim boundary pair missing");
-requireContract(/Last production verification: July 18, 2026/.test(html), "dated semantic verification missing");
-requireContract(/46/.test(html) && /178,216/.test(html) && /93,169/.test(html) && /145/.test(html) && /2013–2024/.test(html), "verified facts or vintage missing");
+requireContract(/Follow tagged small mammals across years of return visits\./.test(html), "plain-language poster promise missing");
+requireContract(/class="poster-cta"[\s\S]*?<span>Pick a place<\/span>/.test(html), "single poster CTA missing");
+requireContract(/One animal in a much bigger field story\./.test(html), "brief below-fold suite bridge missing");
+requireContract(/href="https:\/\/tgilbert14\.github\.io\/NEON-Driver-Cascade\/"/.test(html), "Driver suite destination missing");
+requireContract(!/(Who came back\?|Is the population changing\?|Who shares the night\?|What this can tell you|What this cannot tell you)/.test(html), "retired long-form documentary sections remain");
+requireContract(!/(178,216|93,169|2013–2024|hero-facts|signal-bar|measure-grid)/.test(html), "poster must not carry a synthetic metric or methods band");
 requireContract(!/\bfetch\s*\(/.test(html), "cover must not make an unsolicited prewarm request");
 requireContract(!/(?:href|src)="http:\/\//.test(html), "cover contains an insecure link or asset URL");
 requireContract(/rel="canonical" href="https:\/\/tgilbert14\.github\.io\/NEON-Small-Mammal-Tracker-App\/"/.test(html), "canonical URL missing");
@@ -53,10 +56,12 @@ requireContract(/assets\/pacific-pocket-mouse-sherman-trap-usgs\.jpg/.test(html)
 requireContract(/Cheryl Brehme, USGS/.test(html) && /Public domain/.test(html), "visible documentary photo credit missing");
 requireContract(!/(hero-mobile-v1|og-habitat-v2|og-card-v3-source)/.test(html), "retired generated artwork is still referenced");
 requireContract(!/min-width:\s*320px/.test(html), "fixed 320px body width breaks scrollbar-adjusted reflow");
-requireContract(/\.nav-links \.nav-open \{[\s\S]{0,80}min-height: 44px;/.test(html), "mobile launch target must be at least 44px high");
+requireContract(/\.poster-cta \{[\s\S]{0,100}min-height: 52px;/.test(html), "poster CTA must exceed the 44px touch target");
+requireContract(/@media \(max-width: 760px\)/.test(html) && /@media \(max-width: 360px\)/.test(html), "mobile and narrow reflow contracts missing");
+requireContract(/@media \(prefers-reduced-motion: reduce\)/.test(html), "reduced-motion alternative missing");
 
 const liveLinks = [...html.matchAll(/<a\b[^>]*href="https:\/\/019ec337-7100-317e-5052-c3bf32ffcb79\.share\.connect\.posit\.cloud\/"[^>]*>/g)].map((match) => match[0]);
-requireContract(liveLinks.length === 6, `expected six purposeful live-app controls, found ${liveLinks.length}`);
+requireContract(liveLinks.length === 1, `expected one primary live-app control, found ${liveLinks.length}`);
 for (const link of liveLinks) {
   requireContract(/target="_blank"/.test(link) && /rel="[^"]*noopener[^"]*"/.test(link), "live-app controls must open safely in a new tab");
 }
@@ -64,19 +69,7 @@ for (const link of liveLinks) {
 const ids = [...html.matchAll(/\bid="([^"]+)"/g)].map((match) => match[1]);
 requireContract(new Set(ids).size === ids.length, "duplicate HTML id");
 
-const suiteUrls = [
-  "NEON-Driver-Cascade/",
-  "NEON-Plant-Phenology-Explorer/",
-  "NEON-Plant-Diversity/",
-  "NEON-Vegetation-Structure-Explorer/",
-  "NEON-Ground-Beetle-Tracker/",
-  "NEON-Mosquito-Pulse/",
-  "NEON-Breeding-Birds/",
-  "NEON-WaterChemistry-Analyte-Viewer-App/",
-  "NEON-My-Little-Inverts/"
-];
-for (const url of suiteUrls) requireContract(html.includes(url), `missing suite destination ${url}`);
-requireContract(/class="suite-link current"[^>]+aria-current="page"[^>]*href="#main"/.test(html), "Small Mammals current-page marker missing");
+requireContract(/class="product-name" aria-current="page">Small Mammal Tracker/.test(html), "Small Mammals current-page marker missing");
 
 for (const path of ["docs/assets/pacific-pocket-mouse-sherman-trap-usgs.jpg", "docs/og-card-v4-source.html", "docs/og-image.jpg"]) {
   requireContract(existsSync(path), `missing image asset ${path}`);
@@ -95,4 +88,4 @@ requireContract(socialWidth === 1200 && socialHeight === 630, `social image is $
 const [heroWidth, heroHeight] = jpegSize("docs/assets/pacific-pocket-mouse-sherman-trap-usgs.jpg");
 requireContract(heroWidth === 4000 && heroHeight === 3000, `documentary hero is ${heroWidth}x${heroHeight}, expected 4000x3000`);
 
-console.log("Cover contract passed: documentary media, persuasive entries, claim boundaries, suite registry, metadata, no-prewarm, and image dimensions.");
+console.log("Cover contract passed: concise Living Poster, documentary media, one CTA, subtle suite bridge, metadata, no-prewarm, and image dimensions.");

--- a/scripts/check_cover.mjs
+++ b/scripts/check_cover.mjs
@@ -49,6 +49,7 @@ requireContract(!/(Who came back\?|Is the population changing\?|Who shares the n
 requireContract(!/(178,216|93,169|2013–2024|hero-facts|signal-bar|measure-grid)/.test(html), "poster must not carry a synthetic metric or methods band");
 requireContract(!/\bfetch\s*\(/.test(html), "cover must not make an unsolicited prewarm request");
 requireContract(!/(?:href|src)="http:\/\//.test(html), "cover contains an insecure link or asset URL");
+requireContract(/rel="icon" href="data:image\/svg\+xml,/.test(html), "local inline favicon missing");
 requireContract(/rel="canonical" href="https:\/\/tgilbert14\.github\.io\/NEON-Small-Mammal-Tracker-App\/"/.test(html), "canonical URL missing");
 requireContract(/og:image:width" content="1200"/.test(html) && /og:image:height" content="630"/.test(html), "social dimensions missing");
 requireContract(/og:image:alt/.test(html) && /twitter:image:alt/.test(html), "social alt text missing");


### PR DESCRIPTION
## Outcome

Replaces the long public Pages documentary with the concise artistic Living Poster that was already approved for the Connect app.

- real USGS Sherman-trap photograph at dominant scale
- exact hook, nine-word promise, and one `Pick a place` CTA
- subtle below-fold suite bridge and source/photo attribution
- 320 px responsive, accessible, reduced-motion and forced-colors states
- no data, science, runtime, manifest, or Connect changes

## Verification

- `node scripts/check_cover.mjs`
- `git diff --check`
- HTML landmark/link/asset validation
- owner visual QA at desktop, 390 px, and 320 px with zero horizontal overflow

The production mismatch was implementation, not cache: Pages was correctly serving the old `docs/index.html`; this PR supplies the missing static Living Poster.