### PR TITLE
Close out the Small Mammal Living Poster release

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,9 +1,10 @@
 # Deploy & migration runbook
 
-**Current production state (verified 2026-07-19): HEALTHY.** Pages and
+**Current production state (verified 2026-07-20): HEALTHY.** Pages and
 <https://019ec337-7100-317e-5052-c3bf32ffcb79.share.connect.posit.cloud/> passed
-semantic health. Pages serves source `eb9e1a3`; Connect deployment #122 serves runtime `bdf56b0`.
-Both still show Cover V4 while Cover V5 completes the pinned-manifest release and live verification.
+semantic and visual health on Cover V5 / Suite Living Poster V1. Merge `c4c46fce`
+is the canonical cover release; Connect deployment #125 published that exact
+revision and started bundle-only with all 91 packages supplied by Connect.
 
 The app migrated to Posit Connect Cloud in June 2026. Connect watches `main`, but no automation may
 push there directly. `.github/workflows/refresh-data.yml` builds and verifies an immutable candidate,

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ turning 46 field sites of capture records into maps, charts, and individual prof
 [![Production](https://img.shields.io/badge/production-healthy-1a7f37)](https://tgilbert14.github.io/NEON-Small-Mammal-Tracker-App/)
 [![Data](https://img.shields.io/badge/data-NEON%20DP1.10072.001-1a7f37)](https://data.neonscience.org/data-products/DP1.10072.001)
 
-**Public status (verified 2026-07-19):** the [Pages landing](https://tgilbert14.github.io/NEON-Small-Mammal-Tracker-App/)
+**Public status (verified 2026-07-20):** the [Pages landing](https://tgilbert14.github.io/NEON-Small-Mammal-Tracker-App/)
 and [Posit Connect Cloud app](https://019ec337-7100-317e-5052-c3bf32ffcb79.share.connect.posit.cloud/)
-are healthy. Pages serves source `eb9e1a3`; Connect deployment #122 serves runtime `bdf56b0`.
-Both retain Cover V4 until the Cover V5 Living Poster candidate completes the pinned-manifest
-release, republish, and exact-revision semantic health checks.
+are healthy on Cover V5 / Suite Living Poster V1. Pages and Connect were released
+from merge `c4c46fce`; Connect deployment #125 published that exact revision and
+completed a bundle-only start with all 91 packages supplied by Connect.
 
 Connect's source points at `main`, but automation never writes there directly. Validated monthly
 refreshes are published to `automation/small-mammal-data-refresh` as a review PR; an intentional

--- a/docs/BUILD-TEST-HANDOFF.md
+++ b/docs/BUILD-TEST-HANDOFF.md
@@ -12,11 +12,10 @@ editing it.
 - Product: NEON DP1.10072.001, small mammal box trapping
 - Public cover: `https://tgilbert14.github.io/NEON-Small-Mammal-Tracker-App/`
 - Public app: `https://019ec337-7100-317e-5052-c3bf32ffcb79.share.connect.posit.cloud/`
-- Release state: **PRODUCTION HEALTHY / PASS 1 + COVER V4 LIVE / COVER V5 IN REVIEW**;
-  Pages source `eb9e1a3e9e91096a1c1a82ebf116bf85d33405e3` and Connect deployment
-  #122 at runtime `bdf56b0` remain the verified production evidence. Cover V5
-  requires its CI-generated manifest, exact-head green run, merge, republish,
-  and live Pages/Connect receipts before this section may call it shipped.
+- Release state: **PRODUCTION HEALTHY / PASS 1 + COVER V5 COMPLETE**. PR #86
+  merged as `c4c46fce3725126231504d8f9610f52e8f929ef8`; Pages published that merge
+  and Connect deployment #125 published the same exact revision. Suite Living
+  Poster V1, the 46-site picker, and primary exploration funnels are verified live.
 - Driver disposition: accepted `CONTEXT`; central suite receipt merged with no Driver
   generation or scientific-artifact byte change
 
@@ -1150,3 +1149,65 @@ Driver implication, and next action.
   run to be fully green, merge PR #86, republish Connect, and verify both live
   entrances at desktop, 390, and 320 pixels before writing the final closeout and
   central Driver learning receipt.
+
+### 2026-07-20 09:02 MST - Cover V5 publication closeout / root
+
+- **Starting state:** clean release branch at `3e66ddcab6119b4ab0cace85a64616cb19cf766b`
+  with the validator-made manifest promoted. Production still exposed Cover V4
+  before the intentional merge; no data, estimator, export, picker, or Driver
+  scientific artifact changed in this release.
+- **Publication result (PASS):** exact-head pinned R 4.5.2 run #41
+  (`29755133857`) passed R parsing, helper contracts, static cover contracts,
+  bundle/index/checksum integrity, offline app sourcing, and committed-manifest
+  equality. PR #86 merged as `c4c46fce3725126231504d8f9610f52e8f929ef8`.
+  Main CI `29755368217`, semantic production smoke `29755368297`, and Pages
+  build/deploy `29755366998` all completed successfully.
+- **Manifest/runtime receipt (PASS):** the promoted `manifest.json` SHA-256 is
+  `3fdf334febde34f93f75430bd5ef7daa61cc36f1d6ef7f540578051bee24d3fc`.
+  Connect deployment #125, history
+  `019f8025-2682-eb5d-2ee6-84b1f3872a6b`, published exact commit `c4c46fce`
+  in five seconds using R 4.5.2 and 91 packages supplied by Connect. Its log
+  resolved `wk@0.9.5` from the complete pinned CRAN URL and the worker reached its
+  listening state; the earlier unsupported empty-protocol failure did not recur.
+- **Pages visual receipt (PASS):** the cache-busted live page was inspected at
+  1200 x 630, 390 x 844, 320 x 568, 320 x 720, and both sides of the 700 and 980 px
+  responsive seams. It showed the exact hook, promise, CTA, Driver route, visible
+  illustration boundary, dominant large trap and recognizable mouse, with no old
+  photograph or horizontal overflow. Live full/compact WebPs matched the versioned
+  SHA-256 hashes `7a1f9c78895868d0e540ad3126cf5af6b46a25ed4d02b8cf9113fa613cf2fe29`
+  and `5fc560601bbb0146ffdfc03e2cf662bc7a8e20dce790f52f218ea1bdba8904a5`.
+- **Connect visual/funnel receipt (PASS):** the same poster rendered in the live app
+  at desktop, 390 x 844, 320 x 568, and 320 x 720 with zero horizontal overflow.
+  On short 320 px devices the persistent app chrome correctly puts the CTA below
+  the first viewport rather than clipping it. Clicking `Meet the mammals` focused
+  `DIV#site-picker-start`; the 46-site picker loaded; JORN opened with all ten tabs,
+  headline metrics, report route, and exploration controls present.
+- **Interaction receipt (PASS):** clicking a species-composition bar opened the
+  full ranked-species modal. Clicking the live population environmental-driver bar
+  changed the overlay from `None` to `Plants flowering (% in flower)` at its
+  selected nine-month lead. The two startup-time Plotly registration warnings are
+  therefore non-blocking initialization noise, not broken click funnels. Browser
+  logs contained only vendor datepicker deprecations and Leaflet hidden-map lookup
+  messages during dynamic view changes; there was no JavaScript exception or
+  Shiny disconnect.
+- **Documentation/classification:** this closeout corrects stale V4/candidate status
+  in README, deploy, project-status, provenance, handoff, and the app-local Driver
+  knowledge package. Classification is `product/UI` plus `suite-platform` and
+  documentation; scientific Driver implication remains **NONE / CONTEXT / HOLD
+  CURRENT OUTPUT**.
+- **Evidence invalidated:** PR #85 / `eb9e1a3` and Connect deployment #122 remain
+  historical Cover V4 receipts, not evidence for the owner-selected artistic
+  poster. The canonical dual-surface Living Poster release is PR #86 / `c4c46fce`
+  plus Connect deployment #125.
+- **Failures/cleanup:** GitHub connector writes returned 403, so authenticated `gh`
+  CLI was used for the draft PR and merge. A temporary Connect history-tab URL
+  failed to load, but the signed-in content dashboard supplied the exact deployment
+  receipt. No generated candidate, failed asset, stale runtime photo, or temporary
+  repository file remains.
+- **Residual risk/ownership:** historical Cover V4 and rejected V3 source media stay
+  versioned and unreferenced as provenance evidence. Connect may emit harmless
+  package-build-minor and Plotly initialization warnings; both primary chart click
+  paths are proven live. The separate owner idea branch was not touched.
+- **Next action:** merge this docs-only closeout, publish the corrected Small Mammal
+  receipt and Suite Living Poster V1 frame contract to the central Driver learning
+  loop, then pause before selecting the next companion app.

--- a/docs/DATA-TAKEAWAYS.md
+++ b/docs/DATA-TAKEAWAYS.md
@@ -7,7 +7,10 @@ _Suite audit — June 2026. NEON DP1.10072.001 (Small Mammal Box Trapping)._
 > cross-site detection are surfaced; compare rows carry p̂/N̂ and suppress misleading raw-count
 > winners; tidy capture/monthly exports and a codebook are production-shipped in runtime merge
 > `1615ab4`. Pinned main CI, semantic Connect health, Pages publication, and the JORN interaction
-> funnel passed on 2026-07-18.
+> funnel passed on 2026-07-18. Cover V5 / Suite Living Poster V1 then shipped in
+> merge `c4c46fce` and Connect deployment #125 on 2026-07-20; it changed no
+> helpers, server logic, bundles, indexes, estimators, exports, or Driver scientific
+> artifacts, so every scientific finding below retains the Pass 1 authority.
 
 This app is the **flagship / gold standard** for its nine companion suite apps. Audited
 through four lenses at once: NEONize (suite cohesion + honest-stats machinery), Fauna (field method

--- a/docs/DRIVER-KNOWLEDGE-PACKAGE.md
+++ b/docs/DRIVER-KNOWLEDGE-PACKAGE.md
@@ -1,6 +1,6 @@
 # Small Mammal Tracker -> Driver knowledge package
 
-Status: **PASS 1 COMPLETE / PRODUCTION VERIFIED**
+Status: **PASS 1 + COVER V5 COMPLETE / PRODUCTION VERIFIED**
 
 Learning disposition: **CONTEXT**
 
@@ -8,7 +8,7 @@ Driver action: **HOLD CURRENT OUTPUT; no Driver artifact byte change**
 
 This package promotes only evidence that passed the pinned app validator and final
 semantic production health. The central suite learning ledger must vendor this exact
-receipt before the next companion pass begins.
+receipt before another companion pass begins.
 
 ## Product identity and immutable evidence
 
@@ -16,20 +16,28 @@ receipt before the next companion pass begins.
   `tgilbert14/NEON-Small-Mammal-Tracker-App`
 - NEON product/table: `DP1.10072.001` / `mam_pertrapnight`
 - Audited base: `39dca56c69ef11188333effefd4b2d5bc28948ee`
-- Final runtime merge/deployment: `1615ab4e74fd16a2698de8431acb862d6cc4cebf`
-- Final exact-head validator: run `29663236510`, job `88129323716`
-- Final main validator: run `29663335706`, job `88129588478`
-- Final semantic production health: run `29663335708`, job `88129588525`
-- Final Pages publication: run `29663335341`
-- Validated raw manifest artifact: R 4.5.2, 91 packages, 117 files, SHA-256
+- Pass 1 scientific/runtime merge: `1615ab4e74fd16a2698de8431acb862d6cc4cebf`
+- Pass 1 exact-head validator: run `29663236510`, job `88129323716`
+- Pass 1 main validator: run `29663335706`, job `88129588478`
+- Pass 1 semantic production health: run `29663335708`, job `88129588525`
+- Pass 1 Pages publication: run `29663335341`
+- Pass 1 validated raw manifest artifact: R 4.5.2, 91 packages, 117 files, SHA-256
   `3fba04eb885b3cb6a9437b8c8b25ade25d44d47f6dcb50add025e754a6de04d7`
-- Canonical deployable manifest: R 4.5.2, 91 packages, 117 files, current runtime
+- Pass 1 canonical deployable manifest: R 4.5.2, 91 packages, 117 files, current runtime
   checksums, eight wall-clock URL-package `Built` timestamps removed, and the
   top-level deployment lane normalized to `Source: CRAN` plus the absolute
   `https://cran.r-project.org` origin Connect requires; SHA-256
   `f6c4a5ff74053b95e22fac7394f1930d2fe2329663737031b1c32f7a1f70bc54`
 - Bundle/index contract: 46/46 expected site bundles loaded with rows and the
   physical-effort schema; national index row counts are 46/604/604; 145 species.
+- Cover V5 / Suite Living Poster V1: PR #86, source head `3e66ddca`, merge
+  `c4c46fce3725126231504d8f9610f52e8f929ef8`; exact-head validator
+  `29755133857`, main validator `29755368217`, semantic production health
+  `29755368297`, and Pages publication `29755366998` all passed.
+- Cover V5 canonical manifest: R 4.5.2, 91 packages, 120 files, SHA-256
+  `3fdf334febde34f93f75430bd5ef7daa61cc36f1d6ef7f540578051bee24d3fc`;
+  Connect deployment #125 published exact `c4c46fce` and passed live JORN and
+  chart-interaction checks.
 
 Final exact-head and main runs passed deterministic Haswell/one-thread OpenBLAS,
 complete R/JavaScript/shell parsing, the six-handler Shiny registration contract, all
@@ -175,6 +183,11 @@ Promote to every later app/subagent brief:
   deployment commit and Pages artifact, then inspect the deployed illustration,
   focus order, CTA-to-picker path, utility controls, focal crop, overflow, and browser
   console. Retry platform HTTP 503s without misclassifying them as source defects.
+- Small Mammal V5 passed that contract: PR #86 merged as `c4c46fce`; exact-head
+  pinned run #41 and all three `main` workflows were green; Pages served the
+  versioned poster assets byte-for-byte; and Connect deployment #125 published the
+  same revision, focused the CTA on the 46-site picker, loaded JORN, and preserved
+  working species- and environmental-driver bar interactions.
 
 Driver disposition remains **CONTEXT / HOLD CURRENT OUTPUT**. These are reusable
 suite design and provenance rules; they do not change a Driver scientific input,
@@ -194,6 +207,6 @@ Driver remains unchanged. Preserve CPUE/MNKA/N-hat as qualified consumer context
 revisit ingestion only after all companion packages are complete and the synthesis
 re-evaluates the exact eligible source pin, join coverage, support, and mechanism.
 
-Next dependency: publish this exact `CONTEXT` receipt to the central Driver suite
-ledger and playbook, with Driver artifacts unchanged. Begin Phenology only after that
-documentation merge is green.
+Next dependency: publish this exact Cover V5 `CONTEXT` receipt to the central
+Driver suite ledger and playbook, with Driver artifacts unchanged, then pause.
+Do not select another companion app until the owner resumes the suite pass.

--- a/docs/EXPERT-REVIEW.md
+++ b/docs/EXPERT-REVIEW.md
@@ -1,6 +1,17 @@
 # Small mammal box trapping — Expert Review by Mara (NEON DP1.10072.001)
 _Devoted product-expert review — June 2026._
 
+> **Current finding state (verified 2026-07-20):** this document preserves the
+> June review and scorecard as historical evidence. Pass 1 resolved its release
+> blockers: Compare now carries detection-qualified p̂/N̂ context and suppresses
+> indefensible raw-count winners; the single-night/index-only share is explicit;
+> tidy capture and monthly-series exports plus a codebook are live; and README/live
+> links and the exact 145-species inventory agree. Pinned CI, semantic Connect
+> health, Pages publication, and the JORN funnel passed. Cover V5 later changed only
+> cover UI/media/manifest inventory, leaving those scientific and data contracts
+> unchanged. Findings at lines below that say “remaining,” “Fix,” or show C+/B/B−
+> grades are the June baseline, not current open work.
+
 > I walked my own product's engine end to end against the trapping SOP and the closed-capture canon, and I'll say it plainly: this is the most honest small-mammal abundance app I have reviewed. The mark-recapture is gated by bout structure exactly the way the literature demands — Schnabel for k≥3, Chapman for k=2, nothing for k=1, ΣR≥3 to report, N̂ clamped to the MNKA floor, the CI built in the 1/N domain then inverted. MNKA is promoted over CPUE as the consumer signal, the Chonk Index honestly refuses to be a Scaled Mass Index, and the long-career flag correctly does NOT treat a 3-year desert heteromyid as a tag error. The `id_uncertain` bug the prior audit logged is fixed (computed outside the `summarise()` now). My remaining quarrel is in one place and it matters: the **two-site Compare table races raw captures / individuals across biomes with a winner-highlight and no detection warning** — that is exactly the within-site-index-as-cross-site-density trap I exist to stop, and the app's own detection card already holds the antidote (a 2× p̂ spread). Fix the compare, surface the single-night share and per-site p̂ as first-class numbers, ship a tidy export, and this is publishable-grade. The science is right; a handful of presentation surfaces let a raw count quietly outrun what the bout structure can defend.
 
 ## Method fidelity (is the NEON protocol represented correctly?)

--- a/docs/IMAGE-PROVENANCE.md
+++ b/docs/IMAGE-PROVENANCE.md
@@ -1,6 +1,12 @@
 # Small Mammal cover image provenance
 
-Status: **CANDIDATE / COVER V5 / SUITE LIVING POSTER V1**
+Status: **CURRENT / COVER V5 / SUITE LIVING POSTER V1**
+
+Production receipt: PR #86 merged as `c4c46fce`; exact-head run
+`29755133857`, main CI `29755368217`, semantic smoke `29755368297`, and Pages
+deployment `29755366998` passed. Connect deployment #125 published that exact
+revision, and the live Pages/Connect poster assets matched the versioned hashes
+below during desktop/390/320 verification on 2026-07-20.
 
 Cover V5 promotes the owner-approved artistic direction that was previously
 shown only in the suite concept board. It replaces Cover V4's documentary-photo

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -4,18 +4,18 @@
 > cold-booted agent doesn't re-flag shipped or deliberately-deferred work. Owned by `triage`; keep it
 > current after every review or ship. Depth: `README.md`, `DEPLOY.md`, `docs/neonize-playbook.md`.
 
-**Last verified against the build and public endpoints:** 2026-07-19 (production
-runtime and Pages merge `eb9e1a3`; Connect remains deployment #122 from `bdf56b0`).
+**Last verified against the build and public endpoints:** 2026-07-20 (Cover V5
+merge `c4c46fce`; Connect deployment #125 from that exact revision).
 
 ## Stage
-- **Pass 1 complete / Cover V5 correction in review:** production Pages and Connect
-  remain healthy, but both still show the Cover V4 documentary treatment until the
-  current Suite Living Poster V1 candidate passes the pinned manifest cycle.
-- Pages source is `eb9e1a3`; Connect deployment #122 remains runtime `bdf56b0`.
-  Cover V5 changes runtime art/CSS/UI and therefore requires an exact validator-made
-  manifest, merge, republish, and live desktop/390/320 verification.
+- **Pass 1 and Cover V5 complete:** Pages and Connect now share the owner-selected
+  Suite Living Poster V1. Exact-head pinned CI, merge, Connect publish, semantic
+  startup, responsive visual QA, and both primary launch funnels are verified.
+- Merge `c4c46fce` is the canonical cover release. Connect deployment #125 published
+  that exact revision with the validator-made manifest, including the complete
+  absolute `wk` 0.9.5 tarball URL that closes the earlier protocol failure.
 - The app is again the **flagship / reference** for honest statistics, reviewed releases, and
-  product patterns. The V5 candidate preserves the selected “Who moves after dark?”
+  product patterns. Cover V5 preserves the selected “Who moves after dark?”
   screenprint, adopts Vegetation's shared Living Poster frame, and converges Pages
   and Connect without changing picker or scientific behavior. Unrelated idea
   branches remain outside this pass.
@@ -33,19 +33,15 @@ runtime and Pages merge `eb9e1a3`; Connect remains deployment #122 from `bdf56b0
 
 - Cross-site detection-qualified compare, single-night/index-only coverage, tidy capture + monthly
   series exports, and a codebook are live.
-- Current production retains the reviewed 1200×630 Cover V4 documentary social
-  card, makes no opaque pre-warm request, and has explicit focus treatment.
-- Current Connect production opens with the concise Cover V4 documentary promise,
-  visible photo boundary, and one CTA into the existing picker. Its persistent
-  controls remain one row at 320px.
+- Current production uses the reviewed 1200×630 Cover V5 screenprint social card,
+  makes no opaque pre-warm request, and has explicit focus treatment.
+- Current Connect production opens with the concise Cover V5 promise, visible
+  editorial-illustration boundary, one Driver route, and one CTA into the existing
+  46-site picker. The CTA moves keyboard focus to that picker.
 - Authority docs now agree on the review-branch release boundary, pinned package provenance,
   semantic health, and the ten-app suite. The in-app About panel links all nine companions.
 
 ## Open / in-flight
-- Cover V5: promote the pinned manifest candidate, require an exact-head green run,
-  merge, republish Connect, and verify both public entrances live. The candidate
-  converges them on the same owner-approved screenprint, large metal box trap,
-  concise hook/promise, illustration boundary, Driver route, and action.
 - Long-term: Shinylive/WebAssembly static export (zero cold-start endgame) — see `DEPLOY.md` Option B.
 
 ## Deliberately deferred / non-goals
@@ -54,9 +50,8 @@ runtime and Pages merge `eb9e1a3`; Connect remains deployment #122 from `bdf56b0
 
 ## P-items
 - **P0 COMPLETE:** pinned release gates and semantic production health are green.
-- **P1 IN REVIEW:** Cover V5 Suite Living Poster assets, social metadata,
-  provenance, and static contracts are complete. Pinned run #40 validated and
-  emitted the exact manifest candidate; that artifact is promoted, while the
-  fully green equality rerun and live mobile QA remain.
+- **P1 COMPLETE:** Cover V5 Suite Living Poster assets, social metadata,
+  provenance, static contracts, exact-head pinned run #41, live desktop/390/320
+  QA, and Pages/Connect release receipts are complete.
 - **P2 COMPLETE:** reviewed `CONTEXT` package is in the central Driver ledger; no Driver byte change.
 - **P3:** evaluate Shinylive only after the Connect release path is stable.


### PR DESCRIPTION
Records the verified Cover V5 release across Pages and Connect; corrects stale V4/candidate status; updates provenance, review finding state, and the Driver knowledge package. Docs-only: no runtime, data, manifest, estimator, export, or Driver artifact bytes change. Local cover and in-app validators pass, as does git diff --check.