### PR TITLE
docs: playbook §9 "How we work" — plan/question/challenge before coding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,9 @@ file. Close every session with a dated `BUILD-TEST-HANDOFF.md` entry tagged with
 tool (`[Codex]` / `[Claude]`) and a one-line next action, so the other agent can pick up
 cold. See `docs/neonize-playbook.md` §8.
 
+Before coding: plan, question, and challenge the work, and always surface at least one
+improvement you notice — see `docs/neonize-playbook.md` §9.
+
 ## Required reading
 
 Before any repository work:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,9 @@
 > on top. Close every session with a dated `BUILD-TEST-HANDOFF.md` entry tagged with your tool
 > (`[Claude]` / `[Codex]`) and a one-line **next action**, so the other agent can pick up cold. See
 > `docs/neonize-playbook.md` §8.
+>
+> **Before you code: plan, question, and challenge the work** — and always name at least one
+> improvement you spot. The how-we-work principles are `docs/neonize-playbook.md` §9.
 
 ## What this is
 

--- a/docs/COVER-MOTION-KIT.md
+++ b/docs/COVER-MOTION-KIT.md
@@ -1,0 +1,108 @@
+# Cover & Motion — Starting Kit (DDL NEON suite)
+
+> **This is a STARTING POINT, not a spec.** Every app's cover begins from the shared archetype below and
+> then **diverges by subject**. The published motion mockups and any placeholder copy/art are **rough
+> outlines to be tested live and rewritten per project** — never ship the placeholder words or a hand-drawn
+> stand-in illustration. Adapt freely; keep only the non-negotiable floor (last section).
+>
+> **For subagents:** read this before building or revamping a cover. It gives you somewhere to start; the
+> owner tunes it per project. When a refinement proves out, promote it to the canonical `TG-Data-Apps`
+> playbook via `curator` (see `neonize-playbook.md` §9).
+
+## Two loved references (the archetype, already shipped)
+
+Both covers use ONE template with different skins — that IS the model.
+
+- **Small Mammal** (`docs/index.html`) — ground `#111512` + **acid `#dce319`** + ember `#e87531` + paper
+  `#f3e8cb`; hook **"Who moves / *after dark?*"**; screenprint of a mouse at an oversized box-trap. CTA
+  "Meet the mammals". *Poster-led.*
+- **Vegetation** (`../NEON-Vegetation-Structure-Explorer/docs/index.html`) — ground `#0c1f16` + lichen
+  `#a8d98d` + **gold `#f0bd4f`** + bark `#c7754e` + paper `#f5f0df`; hook **"Tagged. Measured. / *Still
+  changing.*"**; screenprint of a tagged tree with a diameter tape. CTA "Pick a place". *Poster-led.*
+
+There are also two rough **motion mockups** published as owner Artifacts (the "Design DNA" and the "Motion
+& AI Cover" pages) — treat them as sketches of the *treatment*, not finished covers.
+
+## The shared bones (start here — keep the structure)
+
+- `.poster` full-height dark ground + a radial **corner glow** (the app's accent) + a **`feTurbulence`
+  grain** overlay (`mix-blend-mode: soft-light`, opacity ~.16) — the screenprint feel.
+- `.topline`: **Desert Data Labs** brand + mark (left); one **suite jump → Driver Cascade** (right).
+- `.poster-grid`: `minmax(360px,.84fr) minmax(520px,1.36fr)` — **copy left, art right (art is larger)**.
+- Copy: uppercase accent **eyebrow** (`<PRODUCT> · unofficial`) → huge **serif hook**
+  (`clamp(~4rem, 7.3vw, ~7.6rem)`, `line-height:.82`, `letter-spacing:-.065em`, **one line in the app's
+  accent**) → a one-line **promise** (≤12 words) → **one primary CTA** into the Connect app.
+- Art: a **screenprint illustration** of the subject, full-height, `object-fit:cover`, **bleeding left**
+  into the dark via `linear-gradient(90deg, ground → transparent)`, with an **honesty art-note**
+  ("Editorial illustration — not a field photo or data record").
+- Footer (paper ground): **DPID + CC BY 4.0 + "unofficial, not endorsed"**, a `What am I looking at?`
+  honesty `<details>`, and Source / Feedback links.
+- Responsive at 980 / 700 / 420 / 340; the art stacks on top on phones.
+
+## What each app SWAPS (its own skin — no two alike)
+
+Accent(s) · the hook words + which word carries the accent · the screenprint art + its subject · the CTA
+label · the eyebrow/brand accent · the honesty caption. **Choose a distinct bold accent per app** (acid,
+gold, …) — there is **no shared "house" accent**; the family reads through the *structure*, not the color.
+
+## The motion layer (bring the poster alive — all reduced-motion-safe)
+
+Movement is the default, but it must collapse to a clean, beautiful **static** cover under
+`prefers-reduced-motion: reduce`.
+
+- **Parallax hero** — the art (and copy) drift on scroll + pointer, by depth, on `requestAnimationFrame`
+  (passive scroll listener; transforms only, no layout thrash).
+- **Art with depth** — the subject art as a framed, slightly-tilted card with a big soft drop-shadow (+ a
+  faint accent glow), floating **top-right**; or keep the full-bleed image — both read well.
+- **Scroll reveals** — content blocks fade/slide in via `IntersectionObserver`, staggered.
+- **Scroll-cued mood** — a glow/tint or the palette shifts with scroll progress (e.g. a dawn glow rising
+  through the hero).
+- **Hover micro-interactions** — the CTA fills + lifts; cards lift.
+
+## Motion options to prototype (owner ideas — test per app)
+
+- **Video higher.** The AI cover loop can live UP in the hero (behind or beside the hook), not only lower
+  down the page.
+- **Scroll-video / scrollytelling.** A `<video>` (scroll-scrubbed) or a `<canvas>` whose content is driven
+  by scroll progress — a scene that **changes or conveys the app's story as you scroll** (a tree growing,
+  night falling, a plot filling in with tagged individuals). Prototype it and judge per app; keep a static
+  poster fallback and honour reduced-motion.
+
+## The AI asset pipeline (ChatGPT + Higgsfield)
+
+- **ChatGPT / GPT-image → the still.** Prompt in the app's DNA: *"flat bold WPA-poster screenprint,
+  <subject>, <palette>, limited palette, high contrast, no text, no photorealism, 3:2."* This is the
+  screenprint art (or the scroll-video's first frame).
+- **Higgsfield → the motion.** Image-to-video on that still: a subtle seamless loop, or the scroll-video
+  source. Export muted webm + mp4.
+- **Integration (Claude wires it).** Poster-first `<video muted loop playsinline poster="…" preload="none">`;
+  budget < ~2.5 MB; lazy-load; a `prefers-reduced-motion` guard holds the still. **Log every AI asset in
+  `docs/IMAGE-PROVENANCE.md` with source/date/prompt/hash; AI art is NEVER relabelled as NEON data.**
+
+## Per-app divergence (be creative — the cover follows the subject)
+
+The poster archetype is perfect for a **front-door cover**, but the format should follow what the app *is*:
+
+- **Poster-led** (Small Mammal) — a screenprint hero.
+- **Immersive / scroll-led** (Vegetation) — a "growth" scroll where structure builds as you go; lead with
+  the tap-to-pin Forest Size Lab.
+- **Data-led** (e.g. Mosquito Pulse) — the hero *is* a live chart or interaction.
+- **Systemic / map-led** (Driver-Cascade, the ambassador) — a constellation of the suite, or an animated
+  weather→response cascade.
+
+Same DNA, different personality. **Don't template one layout onto every app** — the owner explicitly does
+not want them to look the same.
+
+## The floor (non-negotiable, even in a rough draft)
+
+Honesty art-note on the illustration + the `What am I looking at?` details · a detection index is never a
+population · AI art labelled and never relabelled as data · `prefers-reduced-motion` honoured · legible
+contrast on both grounds · visible focus ring · 44px touch targets · every asset logged in
+`IMAGE-PROVENANCE.md`. Validate at desktop / 390 / 320, and record the exact Pages artifact + Connect
+deployment commit before calling a cover shipped (`neonize-playbook.md` §7, the Cover Contract).
+
+---
+*Starting kit v0.1 — grew from the Small Mammal + Vegetation Living Posters and the owner's motion
+direction. A rough outline to build from and **alter per project**; enforce the frame with
+`check_cover.mjs` / `check_in_app_landing.mjs`, and promote proven refinements to canonical
+`TG-Data-Apps` via `curator`.*

--- a/docs/COVER-MOTION-KIT.md
+++ b/docs/COVER-MOTION-KIT.md
@@ -68,16 +68,22 @@ Movement is the default, but it must collapse to a clean, beautiful **static** c
   night falling, a plot filling in with tagged individuals). Prototype it and judge per app; keep a static
   poster fallback and honour reduced-motion.
 
-## The AI asset pipeline (ChatGPT + Higgsfield)
+## The AI asset pipeline — tools we own (use these)
 
-- **ChatGPT / GPT-image → the still.** Prompt in the app's DNA: *"flat bold WPA-poster screenprint,
-  <subject>, <palette>, limited palette, high contrast, no text, no photorealism, 3:2."* This is the
-  screenprint art (or the scroll-video's first frame).
-- **Higgsfield → the motion.** Image-to-video on that still: a subtle seamless loop, or the scroll-video
-  source. Export muted webm + mp4.
-- **Integration (Claude wires it).** Poster-first `<video muted loop playsinline poster="…" preload="none">`;
-  budget < ~2.5 MB; lazy-load; a `prefers-reduced-motion` guard holds the still. **Log every AI asset in
-  `docs/IMAGE-PROVENANCE.md` with source/date/prompt/hash; AI art is NEVER relabelled as NEON data.**
+**Owner's toolchain (2026-07): ChatGPT Pro (20×) + a Higgsfield account.** Default to what Pro already
+covers; do not assume paid extras.
+
+1. **Still + graphics → ChatGPT Pro / GPT-image (PRIMARY).** The screenprint hero art and the scroll-video
+   first frame. Prompt in the app's DNA (ready prompts in the appendix below).
+2. **Motion → Sora, included in ChatGPT Pro (PRIMARY).** Image-to-video on the GPT-image still: a slow
+   ambient loop, or the scroll-video source. No extra cost on Pro.
+3. **Motion → Higgsfield (SECONDARY, use sparingly).** Better stylized motion control, but credit-limited
+   (only ~9 credits left as of 2026-07) — reserve for a deliberate A/B vs Sora, not routine passes.
+4. **Integration → Claude wires it.** Poster-first `<video muted loop playsinline poster="…"
+   preload="none">`; budget < ~2.5 MB; lazy-load; `prefers-reduced-motion` holds the still. **A perfect
+   loop is NOT required from the model** — a plain 10–20s clip is fine; Claude makes it loop cleanly in
+   code (short crossfade / opacity dissolve at the loop point). **Log every AI asset in
+   `docs/IMAGE-PROVENANCE.md` with source/date/prompt/hash; AI art is NEVER relabelled as NEON data.**
 
 ## Per-app divergence (be creative — the cover follows the subject)
 
@@ -100,6 +106,39 @@ population · AI art labelled and never relabelled as data · `prefers-reduced-m
 contrast on both grounds · visible focus ring · 44px touch targets · every asset logged in
 `IMAGE-PROVENANCE.md`. Validate at desktop / 390 / 320, and record the exact Pages artifact + Connect
 deployment commit before calling a cover shipped (`neonize-playbook.md` §7, the Cover Contract).
+
+## Ready prompts + how an agent uses them
+
+**How an agent uses this (Claude or Codex):** you can't call ChatGPT/Sora/Higgsfield yourself — so when a
+cover needs art or motion, **hand the owner the exact prompt below** (tuned to the app's DNA), let them
+generate the still (GPT-image) and clip (Sora) in ChatGPT Pro, then **wire the returned asset** into the
+cover (poster-first video, reduced-motion fallback) and log it in `IMAGE-PROVENANCE.md`. Prompt → owner →
+wire. Don't block on it: build the cover with the SVG/CSS stand-in first, drop the real asset in when it lands.
+
+**Small Mammal — GPT-image (the screenprint still):**
+> Bold flat editorial screenprint poster illustration, WPA / national-park style. Scene: a small nocturnal
+> desert mouse pausing at the mouth of an oversized metal Sherman box live-trap, under a starry night sky
+> with a warm gold moon low on the horizon; layered dune silhouettes and a saguaro. Palette limited to deep
+> near-black green (#111512), acid chartreuse-yellow (#dce319) as the single bold accent, warm ember orange
+> (#e87531), and cream (#f3e8cb). Flat confident shapes, high contrast, visible screenprint grain, dramatic
+> but graphic — not photorealistic, no text, no watermark. Compose the mouse and trap toward the lower area
+> with generous dark sky above for a headline. (Aspect: 4:5 portrait for a top-right art card, or 3:4 for a
+> full-height right-column bleed.)
+
+**Small Mammal — Sora (image-to-video, ambient loop from that still):**
+> Animate this poster still with subtle, calm ambient motion for a website cover background: stars twinkle
+> and drift very slowly, a faint haze rolls low over the dunes, the moon glow gently breathes, the mouse
+> gives one small whisker twitch. Minimal slow camera, a barely-perceptible parallax push-in. Keep the exact
+> flat screenprint style and palette; add or change nothing; no text. 8–12 seconds, gentle, start and end on
+> a similar frame (loop-friendly), muted.
+
+**Reusable template (any app):**
+> STILL: "Bold flat editorial screenprint poster, WPA style. Scene: <app subject>. Palette: <app ground> +
+> its ONE bold accent + 1–2 supports. Flat shapes, high contrast, screenprint grain, no text, no
+> photorealism. <aspect>."
+> MOTION: "Animate this still with subtle calm ambient motion suited to <subject> (leaves stirring / water
+> rippling / stars drifting); keep the exact style and palette, add nothing, no text; 8–12s, slow,
+> loop-friendly, muted."
 
 ---
 *Starting kit v0.1 — grew from the Small Mammal + Vegetation Living Posters and the owner's motion

--- a/docs/COVER-MOTION-KIT.md
+++ b/docs/COVER-MOTION-KIT.md
@@ -50,6 +50,11 @@ gold, …) — there is **no shared "house" accent**; the family reads through t
 Movement is the default, but it must collapse to a clean, beautiful **static** cover under
 `prefers-reduced-motion: reduce`.
 
+**This is the LIGHT tier — `neonize`'s base.** Parallax, scroll-reveals, and a scroll-cued mood on a poster
+cover are app-side (this kit). For the DEEP immersive tier — a scroll-scrubbed camera flight, a
+fly-through-the-world scene — `neonize` CALLS the canonical **Mithril** guild + the `scroll-world` /
+`scroll-film` skills (the Higgsfield scroll-scrub pipeline); don't rebuild that here.
+
 - **Parallax hero** — the art (and copy) drift on scroll + pointer, by depth, on `requestAnimationFrame`
   (passive scroll listener; transforms only, no layout thrash).
 - **Art with depth** — the subject art as a framed, slightly-tilted card with a big soft drop-shadow (+ a

--- a/docs/CURATOR-PROMOTION-QUEUE.md
+++ b/docs/CURATOR-PROMOTION-QUEUE.md
@@ -1,0 +1,42 @@
+# Curator promotion queue → canonical `TG-Data-Apps`
+
+> For **`curator`**, run in a session that has `TG-Data-Apps` in scope. This lists what this cross-agent
+> pass added to the **flagship** copies that should be promoted to the **canonical** playbook / LESSONS so
+> every suite app and both tools (Claude Code + ChatGPT/Codex) inherit it. Promote, then sync the per-repo
+> copies. Check an item off when done. (Source PRs: #88 merged, #89 small-mammal, #11 veg, #43 Driver.)
+
+## Promote into the canonical `docs/neonize-playbook.md`
+- [ ] **§9 "How we work"** — plan/question/challenge before coding · curator-gated skills promotion ·
+  know-your-tools + suggest new ones · always propose an improvement.
+- [ ] **§8 "Working across agents"** + the **repo-map / branch-defaults** note — shared front door
+  (`CLAUDE.md` + `AGENTS.md` → same tool-neutral source of truth), the `[tool]`-tagged handoff log as the
+  async channel, cross-vendor PR review, contracts-as-the-trust-layer; and the split **`main` (Small
+  Mammal, Vegetation) vs `master` (Driver-Cascade)** — documented, not renamed.
+- [ ] **§6 manifest byte-determinism recipe** — strip `Built`, canonicalize the geo-pin lane, targeted
+  text-substitution (never a `jsonlite` reserialize), pin `platform` + `locale=C` — plus the "no-local-R
+  merge loop" and the `Regenerate manifest (manual)` reference workflow.
+- [ ] **§7 Cover Contract** — `check_cover.mjs` / `check_in_app_landing.mjs` as mechanical enforcement of
+  the Living Poster frame + `IMAGE-PROVENANCE.md` as a required hash-linked artifact + asset hygiene.
+
+## Promote as a suite-standard doc
+- [ ] **`docs/COVER-MOTION-KIT.md`** — the cover/motion **starting kit** (archetype, per-app skin, the
+  reduced-motion-safe motion layer, the scroll-video ideas, the ChatGPT→Higgsfield asset pipeline, per-app
+  divergence, the floor). Make it the reference every cover build starts from and alters per project.
+
+## Promote into the canonical `.claude/agents/LESSONS.md`
+- [ ] `connor` — manifest **byte-determinism** (both `manifest.json` and, where present, `search_index.rds`).
+- [ ] `neonize` — the **CI-only manifest merge loop** (`contents: read` + no local R) and its escape hatch.
+- [ ] `connor` — **Driver's semantic gate** (`compare_manifests.R`) is the more *robust* pattern than
+  byte-exact `git diff`; a convergence candidate for the siblings — **not urgent** (they already de-flapped
+  via the determinism recipe).
+- [ ] `cass` — Driver is a **derived app** (clone siblings, run `build_cascade.R`); do NOT copy the
+  siblings' regenerate workflow here.
+- [ ] `mara` — Vegetation **channel separation** (`tree_dbh` vs `shrub_sapling_basal`).
+
+## Then sync the per-repo copies
+- [ ] Every suite repo has a `CLAUDE.md` + `.claude/agents/LESSONS.md` (done for veg #11 + Driver #43;
+  verify the rest of the suite — Ground Beetle, Plant Diversity, Phenology, Breeding Birds, Mosquito Pulse).
+- [ ] Each repo's `AGENTS.md` + `CLAUDE.md` front door points at the canonical source of truth and states
+  its branch default; `.gitignore` tracks `.claude/agents/LESSONS.md` (Driver needed a targeted exception).
+
+*Queue authored 2026-07-20 by the cross-agent pass. Delete this file once the queue is drained.*

--- a/docs/neonize-playbook.md
+++ b/docs/neonize-playbook.md
@@ -450,9 +450,34 @@ Rough division by strength (not a rule): Codex for tight visual/UX/prototype ite
 cross-repo diagnosis, science-contract/honesty review, Driver synthesis, and learning-loop upkeep —
 with the handoff log carrying state between them.
 
+## 9. How we work (principles for every session)
+
+These govern every session in either tool; they outrank any single feature.
+
+- **Plan, question, and challenge before you code.** Before anything non-trivial: restate the goal in
+  your own words, surface the load-bearing assumptions, name the risks and the blast radius, and ask
+  whether this is even the right thing to build. A short written plan plus the one sharp question beats
+  charging in — a wrong assumption caught in planning is free; caught in a deploy it is not. Reversible
+  and well-scoped -> proceed. Risky, outward-facing, or ambiguous (a watched-branch change, a rename, a
+  contract/schema edit, anything touching production bytes) -> plan it and confirm first. Standing
+  preference, not a per-task ask.
+- **Promote proven patterns into skills — curator-gated.** When a pattern earns it (used across >=2 apps,
+  or it survived a real reviewed build — not just once in theory), don't leave it buried in one repo:
+  propose it to `curator`, who vets and names it and, via the `skill-creator` skill, turns it into an
+  invokable skill and promotes it to canonical `TG-Data-Apps` so the whole suite and both tools can call
+  it. Bar = proven + reusable; gate = curator approval, so the skill set stays curated, not cluttered.
+  (The Cover Contract §7 and the manifest-determinism recipe §6 are the first two candidates.)
+- **Know your tools; suggest new ones.** Start substantive work by taking stock of what's available —
+  skills, subagents, MCP tools, workflows — and pick the right one instead of hand-rolling. When a task
+  would be better served by a tool we don't have, or a newly-available one fits, say so by name and say
+  what it would do. A capability we forget we have is one we don't have.
+- **Always propose an improvement.** Close substantive work by naming at least one concrete improvement
+  you noticed — even out of scope, even small. Ideas are cheap; the only cost is forgetting to say them.
+  Log the durable ones to `LESSONS.md` / the handoff so they aren't lost.
+
 ---
 
 *Living doc. Plant-diversity (DP1.10058.001) was the first full NEONize; birds/phenology/veg/cascade
-followed. §6–7 now encode the review-branch release boundary, pinned-build evidence, the shared
-off-peak schedule, and the QC-flag generalization. Keep the suite's canonical playbook and each
-app-local copy synchronized whenever these contracts change.*
+followed. §6–9 now encode the review-branch release boundary, pinned-build evidence, the shared
+off-peak schedule, the QC-flag generalization, cross-agent working, and the how-we-work principles.
+Keep the suite's canonical playbook and each app-local copy synchronized whenever these contracts change.*

--- a/docs/neonize-playbook.md
+++ b/docs/neonize-playbook.md
@@ -445,6 +445,13 @@ artifacts in the repo**, and that already works if you keep four things true:
 - **Let the contracts be the trust layer.** The `check_*.mjs` / `verify_*.R` gates and the manifest
   determinism gate (§6) are tool-agnostic referees — neither agent has to trust the other's self-report;
   CI enforces the invariants objectively. Invest in contracts, not agent-specific trust.
+- **Know the map — every repo, both tools.** Each suite repo carries the same front door: `CLAUDE.md`
+  (Claude) + `AGENTS.md` (Codex) pointing at the same tool-neutral docs, plus a project-local
+  `.claude/agents/LESSONS.md`. **Branch defaults are split and must never be assumed:** Small Mammal and
+  Vegetation deploy from **`main`**; **Driver-Cascade deploys from `master`** (Connect Cloud watches it —
+  documented, not renamed, because a rename must repoint the external Connect setting first). Driver's
+  release gate is *semantic* (`compare_manifests.R`), while the byte-exact siblings use `git diff` — worth
+  cross-pollinating (see §6).
 
 Rough division by strength (not a rule): Codex for tight visual/UX/prototype iteration; Claude for
 cross-repo diagnosis, science-contract/honesty review, Driver synthesis, and learning-loop upkeep —

--- a/docs/neonize-playbook.md
+++ b/docs/neonize-playbook.md
@@ -424,6 +424,11 @@ any art/copy/crop change is ONE coordinated PR touching the images, both hash pi
 record together (binaries can't auto-merge). This turns the two `.mjs` files into the reusable "Cover
 Contract" every companion inherits with the Living Poster frame.
 
+**Motion, the scroll-video ideas, per-app divergence, and the ChatGPT + Higgsfield asset pipeline** live in
+`docs/COVER-MOTION-KIT.md` — the rough *starting kit* a subagent builds a cover from and then alters per
+project (the poster archetype is the front-door default; covers can also be immersive-scroll-led or
+data-led depending on the subject — the owner does not want them to look the same).
+
 ## 8. Working across agents (Claude + Codex)
 
 This suite is built by more than one agent — Claude Code and ChatGPT/Codex — often on the same repo,


### PR DESCRIPTION
## What

Bakes in the four working principles you asked to standardize, as **playbook §9 "How we work"**, with front-door pointers from `CLAUDE.md` and `AGENTS.md`:

- **Plan, question, and challenge before you code** — restate the goal, surface assumptions, name the blast radius, and ask whether it's even the right thing. Reversible/well-scoped → proceed; risky/outward-facing/ambiguous (watched-branch change, rename, contract edit) → confirm first.
- **Promote proven patterns into skills — curator-gated** — a pattern that's used across ≥2 apps or survived a real build gets proposed to `curator`, who vets/names it and turns it into an invokable skill (via `skill-creator`) promoted to canonical `TG-Data-Apps`. Bar = proven+reusable; gate = curator.
- **Know your tools; suggest new ones** — take stock of skills/subagents/MCP/workflows before hand-rolling; name a missing or newly-available tool when it fits.
- **Always propose an improvement** — close substantive work by naming ≥1 concrete improvement, log the durable ones.

Docs only; no runtime/manifest/data byte changed. Kept **draft** so you control merge timing — your parallel session is also editing `main` (I merged its cover-review backlog commit `b0d5458` cleanly into #88; this §9 work sits on top and I deliberately left `BUILD-TEST-HANDOFF.md` untouched to avoid an append collision).

## Pending owner decisions (not executed — per the §9 plan-before-code principle)

1. **Mirror the merge-loop fix + cross-agent/§9 docs to Vegetation and Driver-Cascade.** Needs per-repo adaptation: veg also regenerates `search_index.rds` (so its regenerate workflow differs), and Driver-Cascade is a derived, `master`-default app.
2. **Apply the 8 cover cross-review fixes** (recorded in `docs/cover-cross-review-2026-07-20.md`). 7 are manifest-neutral (`scripts/` + docs); only the `ui.R` `<html lang>` fix touches runtime → land that one via the new `Regenerate manifest (manual)` flow.
3. **Rename Driver-Cascade default `master` → `main`.** ⚠️ Risky — verify what Connect Cloud watches *before* any rename, or it can break the deploy.
4. **Develop a DDL style guide** — anchored on the artistic Living Poster covers; one base DNA + a per-project "vibe dial".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4wKHURuTUGcbz91Xp6MEz

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4wKHURuTUGcbz91Xp6MEz)_