### PR TITLE
Remove the visible cover-art disclaimer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,10 @@ jobs:
           # exact retained source tarballs so writeManifest records versions that
           # were really compiled in this validator; never rewrite versions after
           # the fact. Terra remains on CRAN's archive; the other seven packages
-          # come from the immutable 2026-07-15 Posit source snapshot.
+          # come from the immutable 2026-07-15 Posit source snapshot. Keep bslib
+          # at the manifest-reviewed 0.11.0 instead of pak's moving CRAN fallback.
           packages: >
-            shiny, bslib, bsicons, dplyr, tidyr, stringr, tibble,
+            shiny, bslib@0.11.0, bsicons, dplyr, tidyr, stringr, tibble,
             leaflet, DT, shinyjs, shinycssloaders, RColorBrewer, htmltools,
             ggplot2, jsonlite, rsconnect, cpp11,
             url::https://packagemanager.posit.co/cran/2026-07-15/src/contrib/plotly_4.12.0.tar.gz,
@@ -76,7 +77,7 @@ jobs:
             url::https://packagemanager.posit.co/cran/2026-07-15/src/contrib/sp_2.2-1.tar.gz
           pak-version: stable
           dependencies: '"hard"'
-          cache-version: small-mammal-geo-closure-v4
+          cache-version: small-mammal-geo-closure-v5
           cache: always
           install-pandoc: 'false'
           install-quarto: 'false'

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -85,10 +85,11 @@ jobs:
         with:
           # Match validator and eventual manifest provenance exactly. Terra
           # 1.8-50 remains on CRAN's archive; the other seven versions come from
-          # the immutable 2026-07-15 Posit source snapshot.
+          # the immutable 2026-07-15 Posit source snapshot. Keep bslib at the
+          # manifest-reviewed 0.11.0 instead of pak's moving CRAN fallback.
           packages: >
             neonUtilities, dplyr, tibble, tidyr, stringr, jsonlite, shiny,
-            bslib, bsicons, leaflet, DT, shinyjs, shinycssloaders,
+            bslib@0.11.0, bsicons, leaflet, DT, shinyjs, shinycssloaders,
             RColorBrewer, htmltools, ggplot2, cpp11, rsconnect,
             url::https://packagemanager.posit.co/cran/2026-07-15/src/contrib/plotly_4.12.0.tar.gz,
             url::https://cran.r-project.org/src/contrib/Archive/terra/terra_1.8-50.tar.gz,
@@ -101,7 +102,7 @@ jobs:
             url::https://packagemanager.posit.co/cran/2026-07-15/src/contrib/sp_2.2-1.tar.gz
           pak-version: stable
           dependencies: '"hard"'
-          cache-version: small-mammal-refresh-geo-closure-v4
+          cache-version: small-mammal-refresh-geo-closure-v5
           cache: always
           install-pandoc: 'false'
           install-quarto: 'false'

--- a/.github/workflows/regenerate-manifest.yml
+++ b/.github/workflows/regenerate-manifest.yml
@@ -72,8 +72,9 @@ jobs:
           # Exact closure copied from ci.yml so the manifest records versions that
           # were really compiled here. Terra 1.8-50 is the archived GDAL 3.4.1 pin;
           # the other seven packages use the immutable 2026-07-15 Posit source snapshot.
+          # Keep bslib at the manifest-reviewed 0.11.0, never the moving fallback.
           packages: >
-            shiny, bslib, bsicons, dplyr, tidyr, stringr, tibble,
+            shiny, bslib@0.11.0, bsicons, dplyr, tidyr, stringr, tibble,
             leaflet, DT, shinyjs, shinycssloaders, RColorBrewer, htmltools,
             ggplot2, jsonlite, rsconnect, cpp11,
             url::https://packagemanager.posit.co/cran/2026-07-15/src/contrib/plotly_4.12.0.tar.gz,
@@ -87,7 +88,7 @@ jobs:
             url::https://packagemanager.posit.co/cran/2026-07-15/src/contrib/sp_2.2-1.tar.gz
           pak-version: stable
           dependencies: '"hard"'
-          cache-version: small-mammal-geo-closure-v4
+          cache-version: small-mammal-geo-closure-v5
           cache: always
           install-pandoc: 'false'
           install-quarto: 'false'

--- a/docs/BUILD-TEST-HANDOFF.md
+++ b/docs/BUILD-TEST-HANDOFF.md
@@ -1411,3 +1411,66 @@ Driver implication, and next action.
   that exact head is green and PR head/base remain unchanged and mergeable, merge #91,
   require post-merge main CI plus Connect semantic health, then exercise the repaired
   review publisher with a no-download refresh before the next full scheduled data pull.
+
+### 2026-08-05 19:31 MST - visible illustration-badge removal candidate / [Codex]
+
+- **Outcome/source:** implemented on isolated branch `codex/remove-visible-art-badge`
+  from GitHub-verified default `main` commit
+  `86a94bcf53037fa693781b005d90c89349c746c6`. No historical receipt was rewritten.
+  Classification is `product/UI` plus `suite-platform`; science, data, and Driver
+  disposition remain `CONTEXT / NO DRIVER BYTE CHANGE`.
+- **Scope:** removed only the visible illustration `figcaption` from the Pages and
+  in-app Living Posters and deleted the now-dead `.art-note` /
+  `.smt-poster-art figcaption` rules. The approved hook, promise, CTA, responsive
+  image family and hashes, exact descriptive alt text, provenance receipt, DPID,
+  sampled-capture honesty disclosure, and all scientific claim limits are unchanged.
+  The cover contracts now fail if the badge markup, sentence, or retired CSS returns.
+- **Normative closeout:** current provenance, Cover Kit, Driver package, project
+  status, and app-local playbook now place editorial-art status in meaningful alt
+  text and durable provenance without spending poster space on an ornamental badge.
+  This does not alter the factual Cover V5 publication history above.
+- **Static/local results (PASS):** all R files parsed under local R 4.5.3; Node
+  syntax, `check_custom_message_handlers.mjs`, `check_cover.mjs`,
+  `check_in_app_landing.mjs`, `check_workflow_runtime_budget.mjs`, shell syntax for
+  `post_deploy_smoke.sh`, and `git diff --check` passed. The local library lacks
+  `dplyr`, so helper/offline-source tests remain the pinned validator's job.
+- **Focused visual/accessibility result (PASS):** a read-only local Pages render was
+  inspected at 1280×900, 390×844, and 320×720. At both compact widths the art leads,
+  the 52 px CTA stays inside the first viewport, the root widths are exactly
+  375/375 and 305/305 (client/scroll), the badge count is zero, the image loads with
+  the unchanged alt, and the console has no warning/error. Keyboard order is Skip →
+  Driver → CTA, each with a 3 px visible outline. This is Pages source evidence, not
+  a Connect publication receipt.
+- **Expected manifest gate (BLOCKED pending pinned regeneration):**
+  `Rscript --vanilla scripts/verify_bundle.R` loaded all 46 bundles and indexes,
+  then failed closed on exactly `ui.R` and `www/styles.css`. Their committed/new
+  MD5 values are `0269b7c678d0e22f55efae8e69095010` →
+  `378a4e69dec6606007fdfdf6e4c08709` and
+  `7a854fe0d93704c0b3f8b7753e433a6a` →
+  `3649840101086fbc7264011193595240`. Do not hand-edit the manifest or generate it
+  from this noncanonical macOS/R 4.5.3 library.
+- **Exact derived-byte route:** after this source commit is pushed to a review
+  branch, dispatch **`Regenerate manifest (manual)`** on that branch (no custom
+  inputs). Its pinned Ubuntu 22.04/R 4.5.2 validator uploads
+  `small-mammal-manifest-promotion-<source-sha>` and its restricted publisher
+  commits the verified `manifest.json` only if the branch still equals that source
+  SHA. Ordinary PR CI also exposes `small-mammal-manifest-<source-sha>` after all
+  preceding gates pass.
+- **Post-merge publication/health route:** Connect is git-backed and watches
+  `main`; the reviewed merge is the automatic publication trigger. Confirm Connect
+  **Last deployed** and use the signed-in **Republish** control only if it lags.
+  Main push also runs **`Verify production after main publication`** / job
+  `semantic_health`; `scripts/post_deploy_smoke.sh` rejects host error text and
+  requires marker name `ddl-app-ready` (the UI emits content
+  `small-mammal-tracker-v1`) on the Connect surface.
+- **Writes/cleanup/residual risk:** no push, PR, workflow dispatch, manifest edit,
+  Connect action, Pages deployment, production probe, data change, or Driver write
+  occurred. Temporary local preview servers were stopped and their agent browser
+  tab was closed. Exact manifest bytes, full R fixtures/offline boot, in-app runtime
+  geometry, merge identity, Connect restore, and semantic production health remain
+  unclaimed until the review/publish ladder runs.
+- **Next action:** commit this source candidate locally; then publish it only when
+  authorized, run the exact manual manifest workflow, inspect and retain its direct-
+  child bot commit, require literal-head CI, merge intentionally, confirm the exact
+  Connect-deployed commit, and close with live Pages/Connect 1280/390/320 plus picker
+  interaction evidence.

--- a/docs/BUILD-TEST-HANDOFF.md
+++ b/docs/BUILD-TEST-HANDOFF.md
@@ -1474,3 +1474,44 @@ Driver implication, and next action.
   child bot commit, require literal-head CI, merge intentionally, confirm the exact
   Connect-deployed commit, and close with live Pages/Connect 1280/390/320 plus picker
   interaction evidence.
+
+### 2026-08-05 19:50 MST - bslib moving-repository repair / [Codex]
+
+- **Failed-run evidence (FAIL, production unchanged):** manual **Regenerate
+  manifest (manual)** run
+  [`31066379084`](https://github.com/tgilbert14/NEON-Small-Mammal-Tracker-App/actions/runs/31066379084),
+  generate job
+  [`92504852729`](https://github.com/tgilbert14/NEON-Small-Mammal-Tracker-App/actions/runs/31066379084/job/92504852729),
+  passed every prior dispatch, checkout, pinned-R, dependency-setup, numeric, and
+  source/static gate. Its first manifest generation then failed closed: the
+  versionless `bslib` request had resolved `0.12.0` from moving repository
+  `https://cran.rstudio.com`, while committed `manifest.json` records reviewed
+  `bslib` `0.11.0` from the dated Jammy snapshot.
+- **Root cause and repair:** the CI `contracts`, scheduled/manual refresh
+  `build_candidate`, and manual regeneration `generate` dependency lanes all left
+  `bslib` versionless. Each now requests `bslib@0.11.0`. CI and manual regeneration
+  move `small-mammal-geo-closure-v4` → `small-mammal-geo-closure-v5`; refresh moves
+  `small-mammal-refresh-geo-closure-v4` →
+  `small-mammal-refresh-geo-closure-v5`. The cache rollover prevents any earlier
+  versionless closure from satisfying the new run.
+- **Executable boundary:** `scripts/check_workflow_runtime_budget.mjs` now requires
+  the `bslib@0.11.0` request and exact new cache namespace in all three
+  manifest-producing jobs, in addition to the existing action pins, cold-build
+  budgets, and `cache: always` contract. `scripts/write_manifest.R` and its
+  moving-repository gate are unchanged; the repair changes installation inputs,
+  not provenance after the fact.
+- **Local result (PASS):** Ruby/Psych parsed all three workflows; the enhanced
+  workflow runtime/cache contract and an independent exact-count audit passed;
+  cover and in-app landing contracts passed; `git diff --check` passed. This local
+  macOS/R 4.5.3 library cannot reproduce the authoritative Ubuntu 22.04/R 4.5.2
+  dependency installation, so no regenerated manifest or full bundle PASS is
+  claimed.
+- **Writes/classification:** workflow, executable workflow-contract, and this
+  append-only receipt only; classification `suite-platform / release
+  determinism`. No app/science/data/manifest/Driver byte, push, dispatch,
+  publisher, Connect, Pages, or production state changed.
+- **Next action:** commit this repair locally, then push only when authorized and
+  redispatch **Regenerate manifest (manual)** from the exact new review head. Treat
+  the rolled cache as a cold closure, require generated `bslib` `0.11.0` with dated
+  snapshot provenance and no moving `RemoteRepos`, inspect the immutable promotion
+  artifact/direct-child bot commit, and require literal-head CI before merge.

--- a/docs/COVER-MOTION-KIT.md
+++ b/docs/COVER-MOTION-KIT.md
@@ -33,8 +33,8 @@ There are also two rough **motion mockups** published as owner Artifacts (the "D
   (`clamp(~4rem, 7.3vw, ~7.6rem)`, `line-height:.82`, `letter-spacing:-.065em`, **one line in the app's
   accent**) → a one-line **promise** (≤12 words) → **one primary CTA** into the Connect app.
 - Art: a **screenprint illustration** of the subject, full-height, `object-fit:cover`, **bleeding left**
-  into the dark via `linear-gradient(90deg, ground → transparent)`, with an **honesty art-note**
-  ("Editorial illustration — not a field photo or data record").
+  into the dark via `linear-gradient(90deg, ground → transparent)`. Carry its editorial-art status in
+  meaningful alt text and the durable provenance receipt; do not add a redundant visible badge.
 - Footer (paper ground): **DPID + CC BY 4.0 + "unofficial, not endorsed"**, a `What am I looking at?`
   honesty `<details>`, and Source / Feedback links.
 - Responsive at 980 / 700 / 420 / 340; the art stacks on top on phones.
@@ -120,8 +120,8 @@ link. Render the actual page and deliver the image inline so they can judge it w
 
 ## The floor (non-negotiable, even in a rough draft)
 
-Honesty art-note on the illustration + the `What am I looking at?` details · a detection index is never a
-population · AI art labelled and never relabelled as data · `prefers-reduced-motion` honoured · legible
+Meaningful illustration alt text + durable provenance + the `What am I looking at?` details · a detection
+index is never a population · AI art recorded and never relabelled as data · `prefers-reduced-motion` honoured · legible
 contrast on both grounds · visible focus ring · 44px touch targets · every asset logged in
 `IMAGE-PROVENANCE.md`. Validate at desktop / 390 / 320, and record the exact Pages artifact + Connect
 deployment commit before calling a cover shipped (`neonize-playbook.md` §7, the Cover Contract).

--- a/docs/DRIVER-KNOWLEDGE-PACKAGE.md
+++ b/docs/DRIVER-KNOWLEDGE-PACKAGE.md
@@ -160,7 +160,8 @@ Promote to every later app/subagent brief:
   prompt, hashes, and validators together so approval cannot be mistaken for ship.
 - Standardize the **frame**, not the subject: DDL identity plus one Driver suite
   route; a 3–7-word hook; one plain-language promise; one contextual CTA; one
-  dominant editorial image; visible image/data boundary; compact scope, honesty,
+  dominant editorial image with meaningful alt text and durable provenance; no
+  ornamental illustration badge; compact scope, honesty,
   Source, and Feedback footer. Each app still owns its palette, motif, copy, focal
   position, and scientific limitation.
 - A companion cover should earn the first click before explaining the whole app.
@@ -168,12 +169,12 @@ Promote to every later app/subagent brief:
   it removes the second marketing bridge, feature directory, metrics, and methods
   from the cover. Driver—not every companion cover—is the suite ambassador.
 - Artistic imagery needs the same evidence discipline as documentary media. The
-  screenprint is visibly labeled as editorial illustration, avoids data marks and
-  exact-species claims, and is paired with an honesty note that capture records do
+  screenprint is identified as editorial illustration in alt text and provenance,
+  avoids data marks and exact-species claims, and is paired with an honesty note that capture records do
   not alone measure total population, complete movement, causal change, or
   landscape-wide abundance.
 - Treat Pages and Connect as one invitation with two surfaces. The same hook,
-  promise, illustration, disclosure, Driver route, and CTA intent now lead into the
+  promise, illustration authority, Driver route, and CTA intent now lead into the
   unchanged site picker; a Pages-only swap would repeat the mismatch this release
   exists to fix.
 - Treat narrow responsive QA as a release gate. Validate the image-first seam,

--- a/docs/IMAGE-PROVENANCE.md
+++ b/docs/IMAGE-PROVENANCE.md
@@ -58,8 +58,8 @@ concept and the production asset.
   for responsive derivatives and the social card
 - Alt text: “Editorial screenprint of a small nocturnal mouse emerging from an
   oversized metal box live trap beneath a starry sky.”
-- Visible disclosure: “Editorial illustration—not a field photograph or data
-  record.”
+- Surface policy: meaningful alt text and this durable receipt carry the image's
+  editorial-art status; the cover intentionally has no separate illustration badge.
 
 Generation brief:
 
@@ -91,7 +91,7 @@ were made after the production image was selected.
 | Connect compact | `www/assets/small-mammal-living-poster-840.webp` | 840 x 473 | 105,152 | `5fc560601bbb0146ffdfc03e2cf662bc7a8e20dce790f52f218ea1bdba8904a5` |
 
 The Pages and Connect files are byte-identical copies so both entrances keep the
-same art, crop vocabulary, disclosure, and approved promise. Because the `www/`
+same art, crop vocabulary, accessible art status, and approved promise. Because the `www/`
 files are runtime assets, they require a validator-generated `manifest.json`
 before Connect deployment.
 
@@ -169,8 +169,8 @@ product, or field photograph**, and must not be relabeled as one on any surface.
 ## Release contract
 
 `scripts/check_cover.mjs` verifies the exact approved hook, one-promise/one-CTA
-poster budget, shared Suite Living Poster frame, responsive image set, visible
-illustration disclosure, provenance hashes, social metadata, scope boundary,
+poster budget, shared Suite Living Poster frame, responsive image set, meaningful
+alt text, absence of a redundant visible illustration badge, provenance hashes, social metadata, scope boundary,
 and responsive/accessibility rules. `scripts/check_in_app_landing.mjs` verifies
 the same copy and asset authority inside Connect while preserving the functional
 site-picker controls. Any art, copy, crop, or asset change requires this record

--- a/docs/index.html
+++ b/docs/index.html
@@ -252,26 +252,6 @@
       object-position: 61% center;
       filter: saturate(.98) contrast(1.03);
     }
-    .art-note {
-      position: absolute;
-      z-index: 2;
-      right: 5vw;
-      bottom: 24px;
-      min-height: 30px;
-      display: inline-flex;
-      align-items: center;
-      margin: 0;
-      padding: 5px 9px;
-      border: 1px solid rgba(243, 232, 203, .18);
-      border-radius: 999px;
-      color: var(--paper);
-      background: rgba(17, 21, 18, .86);
-      box-shadow: 0 4px 18px rgba(0, 0, 0, .22);
-      font-size: .69rem;
-      line-height: 1.3;
-      letter-spacing: .035em;
-    }
-
     footer {
       padding: 30px 24px 38px;
       color: #5b665d;
@@ -338,16 +318,6 @@
         min-height: 300px;
         object-position: 72% 60%;
       }
-      .art-note {
-        right: 16px;
-        bottom: 8px;
-        left: 16px;
-        width: fit-content;
-        max-width: calc(100% - 32px);
-        min-height: 28px;
-        font-size: .6rem;
-        line-height: 1.25;
-      }
       .poster-copy {
         order: 2;
         width: calc(100% - 32px);
@@ -391,12 +361,11 @@
 
     @media (prefers-contrast: more) {
       .promise { color: var(--paper); }
-      .art-note { background: var(--night); border-color: var(--paper); }
       footer { color: #253128; }
     }
 
     @media (forced-colors: active) {
-      .brand-mark, .button, .art-note { border: 2px solid ButtonText; }
+      .brand-mark, .button { border: 2px solid ButtonText; }
     }
   </style>
 </head>
@@ -438,7 +407,6 @@
             fetchpriority="high" decoding="async"
             alt="Editorial screenprint of a small nocturnal mouse emerging from an oversized metal box live trap beneath a starry sky.">
         </picture>
-        <figcaption class="art-note">Editorial illustration—not a field photograph or data record.</figcaption>
       </figure>
     </div>
   </main>

--- a/docs/neonize-playbook.md
+++ b/docs/neonize-playbook.md
@@ -399,10 +399,11 @@ so Driver and every in-app sibling directory can reach it.
 **Suite Living Poster V1:** every companion Pages cover uses the same structural frame:
 focusable skip target; DDL topline plus one Driver route; a 3–7-word hook; one <=12-word
 promise; one contextual CTA; one dominant app-specific editorial image in a responsive
-`picture`; visible art/data boundary; and a compact scope/honesty/Source/Feedback footer.
+`picture` with meaningful alt text and durable provenance; no ornamental illustration
+badge; and a compact scope/honesty/Source/Feedback footer.
 No metrics, methods band, feature cards, second CTA, or full companion directory. Reuse
 the grammar, not a clone: each app owns its palette, motif, copy, focal crop, and scientific
-limitation. Carry a compact echo of the same hook, promise, art, disclosure, Driver route,
+limitation. Carry a compact echo of the same hook, promise, art authority, Driver route,
 and action into the functional app without replacing its task flow. Validate both surfaces
 at desktop, 390px, and 320px using the actual framework gutters and complete persistent
 controls; record the exact Pages artifact and Connect deployment commit before calling the

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -42,6 +42,11 @@ merge `c4c46fce`; Connect deployment #125 from that exact revision).
   semantic health, and the ten-app suite. The in-app About panel links all nine companions.
 
 ## Open / in-flight
+- **Suite-platform (local candidate, 2026-08-05):** remove the ornamental
+  illustration badge from Pages and the in-app Living Poster while preserving the
+  exact art, descriptive alt text, durable provenance, and visible scientific
+  limit. Static and local responsive checks pass; the pinned validator must still
+  regenerate `manifest.json` before review can turn this into a release.
 - **Suite-platform (draft PR #88):** manifest merge-loop fix — adds the manual
   `Regenerate manifest` workflow (Option A: validator writes its own manifest back,
   killing the download-artifact round-trip) plus the cross-agent working docs (playbook

--- a/manifest.json
+++ b/manifest.json
@@ -3407,7 +3407,7 @@
       "checksum": "13f0f54d85b54d602e5050d95e0da79f"
     },
     "ui.R": {
-      "checksum": "0269b7c678d0e22f55efae8e69095010"
+      "checksum": "378a4e69dec6606007fdfdf6e4c08709"
     },
     "www/app.js": {
       "checksum": "4fab7f639eafc7839bd929dafcd32fb0"
@@ -3440,7 +3440,7 @@
       "checksum": "03caa0fdc9353ecf3495715d7e5f11f5"
     },
     "www/styles.css": {
-      "checksum": "7a854fe0d93704c0b3f8b7753e433a6a"
+      "checksum": "3649840101086fbc7264011193595240"
     },
     "www/vendor/confetti-1.9.2.browser.min.js": {
       "checksum": "9ffc3c59368462a9486359dfc5ed6ba8"

--- a/scripts/check_cover.mjs
+++ b/scripts/check_cover.mjs
@@ -70,7 +70,8 @@ requireContract(!/(One trap night|A whole population story|Follow tagged small m
 requireContract(/<picture>[\s\S]*?small-mammal-living-poster-840\.webp 840w,[\s\S]*?small-mammal-living-poster\.webp 1672w[\s\S]*?small-mammal-living-poster\.png/.test(html), "responsive Living Poster art set is incomplete");
 requireContract(/width="1672" height="941"[\s\S]{0,120}fetchpriority="high" decoding="async"/.test(html), "poster art needs intrinsic dimensions and high-priority async decoding");
 requireContract(/alt="Editorial screenprint of a small nocturnal mouse emerging from an oversized metal box live trap beneath a starry sky\."/.test(html), "art alt text drifted");
-requireContract(/Editorial illustration—not a field photograph or data record\./.test(html), "visible illustration boundary missing");
+requireContract(!/Editorial illustration—not a field photograph or data record\./.test(html), "poster must omit the redundant visible illustration badge");
+requireContract(!/<figcaption\b[^>]*class="art-note"/i.test(html) && !/\.art-note\b/.test(html), "poster retains illustration-badge markup or dead CSS");
 requireContract(!/(pacific-pocket-mouse-sherman-trap-usgs|small-mammal-field-usgs|Photo source|Cheryl Brehme)/.test(html), "historical documentary media remains live");
 
 // Footer honesty and metadata.
@@ -98,7 +99,6 @@ requireContract(/\.button \{[\s\S]{0,120}min-height:\s*52px/.test(html), "CTA mu
 requireContract(/\.suite-jump \{[\s\S]{0,100}min-height:\s*44px/.test(html), "suite jump lacks a 44px touch target");
 requireContract(/\.honesty summary \{[\s\S]{0,120}min-height:\s*44px/.test(html), "honesty disclosure lacks a 44px touch target");
 requireContract(/\.footer-links a \{[\s\S]{0,100}min-height:\s*44px/.test(html), "footer links lack 44px touch targets");
-requireContract(/\.art-note \{[\s\S]{0,460}background:\s*rgba\(17, 21, 18, \.86\)/.test(html), "illustration disclosure lacks a reliable contrast scrim");
 requireContract(/@media \(max-width: 700px\)/.test(html) && /@media \(max-width: 420px\) and \(max-height: 860px\)/.test(html) && /@media \(max-width: 340px\)/.test(html), "responsive seams are incomplete");
 requireContract(/@media \(prefers-reduced-motion: reduce\)/.test(html), "reduced-motion alternative missing");
 requireContract(/@media \(prefers-contrast: more\)/.test(html) && /@media \(forced-colors: active\)/.test(html), "high-contrast accommodations missing");

--- a/scripts/check_in_app_landing.mjs
+++ b/scripts/check_in_app_landing.mjs
@@ -37,7 +37,7 @@ requireContract(ui.includes('`aria-labelledby` = "smt-poster-title"') && ui.incl
 requireContract(ui.includes("Desert Data Labs") && ui.includes("Whole suite: ") && ui.includes("https://tgilbert14.github.io/NEON-Driver-Cascade/"), "shared DDL/Driver topline is incomplete");
 requireContract(ui.includes("NEON Small Mammal Tracker · unofficial"), "app eyebrow or unofficial boundary missing");
 requireContract(ui.includes("Public NEON DP1.10072.001 · sampled capture records—not total population or measured landscape effects"), "first-frame scientific boundary missing");
-requireContract(ui.includes("Editorial illustration—not a field photograph or data record."), "illustration disclosure missing");
+requireContract(!ui.includes("Editorial illustration—not a field photograph or data record."), "in-app poster must omit the redundant visible illustration badge");
 requireContract(ui.includes("Editorial screenprint of a small nocturnal mouse") && ui.includes("oversized metal box live trap beneath a starry sky."), "art alt text drifted");
 requireContract(ui.includes('asset_url("assets/small-mammal-living-poster.png")'), "PNG fallback is not cache-busted");
 requireContract(ui.includes('asset_url("assets/small-mammal-living-poster.webp")') && ui.includes('asset_url("assets/small-mammal-living-poster-840.webp")'), "responsive WebP set is incomplete");
@@ -60,7 +60,7 @@ requireContract(/\.picker-start:focus-visible\s*\{[^}]*outline:\s*3px solid var\
 requireContract(/\.smt-poster h1\s*\{[\s\S]{0,260}font-family:\s*Iowan Old Style/.test(css), "editorial serif headline drifted");
 requireContract(/\.smt-poster-cta\s*\{[\s\S]{0,180}min-height:\s*48px/.test(css), "poster CTA is not at least 48px tall");
 requireContract(/\.smt-poster-cta\s*\{[\s\S]{0,260}gap:\s*\.35em[\s\S]{0,100}box-sizing:\s*border-box/.test(css), "poster CTA spacing or width containment drifted");
-requireContract(/\.smt-poster-art figcaption\s*\{[\s\S]{0,420}color:\s*#f3e8cb[\s\S]{0,100}background:\s*rgba\(17, 21, 18, \.9\)/.test(css), "art disclosure lost its contrast scrim");
+requireContract(!/\.smt-poster-art\s+figcaption\b/.test(css), "retired illustration-badge CSS remains");
 requireContract(css.includes("@media (max-width: 760px)") && css.includes("@media (max-width: 420px)") && css.includes("@media (max-width: 350px)"), "responsive poster seams are incomplete");
 requireContract(/@media \(max-width: 760px\)[\s\S]{0,360}\.smt-poster-art\s*\{[^}]*grid-row:\s*1/.test(css), "mobile art-first order drifted");
 requireContract(/@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.smt-poster-cta\s*\{\s*transition:\s*none/.test(css), "poster CTA lacks reduced-motion handling");
@@ -80,7 +80,7 @@ for (const [path, expected] of Object.entries(assets)) {
 }
 
 // The Pages (docs/) and Connect (www/) entrances must ship byte-identical art so
-// both doors keep the same crop, disclosure, and approved promise. Hash pins alone
+// both doors keep the same crop, art authority, and approved promise. Hash pins alone
 // don't guarantee it — assert the bytes directly across the two copies.
 for (const runtimePath of Object.keys(assets)) {
   const pagesPath = runtimePath.replace(/^www\//, "docs/");

--- a/scripts/check_workflow_runtime_budget.mjs
+++ b/scripts/check_workflow_runtime_budget.mjs
@@ -2,7 +2,8 @@ import fs from "node:fs";
 
 const PINNED_SETUP_R_DEPS =
   "r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6";
-const SHARED_CACHE_VERSION = "small-mammal-geo-closure-v4";
+const PINNED_BSLIB = "bslib@0.11.0";
+const SHARED_CACHE_VERSION = "small-mammal-geo-closure-v5";
 
 function fail(message) {
   throw new Error(`Workflow runtime-budget contract failed: ${message}`);
@@ -44,6 +45,9 @@ function requireCachedClosure(path, jobName, expectedCacheVersion) {
   }
 
   const step = steps[0];
+  if (!step.includes(PINNED_BSLIB)) {
+    fail(`${path} jobs.${jobName} must install ${PINNED_BSLIB}`);
+  }
   if (!step.includes(`cache-version: ${expectedCacheVersion}`)) {
     fail(`${path} jobs.${jobName} must use cache-version ${expectedCacheVersion}`);
   }
@@ -69,8 +73,8 @@ if (timeoutMinutes(refresh, "build_candidate") < 100) {
 
 requireCachedClosure(ci, "contracts", SHARED_CACHE_VERSION);
 requireCachedClosure(regeneration, "generate", SHARED_CACHE_VERSION);
-requireCachedClosure(refresh, "build_candidate", "small-mammal-refresh-geo-closure-v4");
+requireCachedClosure(refresh, "build_candidate", "small-mammal-refresh-geo-closure-v5");
 
 console.log(
-  "Workflow runtime-budget contract passed: 100-minute PR/regeneration budgets and always-on exact-closure caches.",
+  "Workflow runtime-budget contract passed: 100-minute PR/regeneration budgets, pinned bslib, and rolled exact-closure caches.",
 );

--- a/ui.R
+++ b/ui.R
@@ -76,9 +76,6 @@ small_mammal_poster <- function(show_cta = TRUE) {
           width = "1672", height = "941", fetchpriority = "high",
           decoding = "async"
         )
-      ),
-      tags$figcaption(
-        "Editorial illustration—not a field photograph or data record."
       )
     )
   )

--- a/www/styles.css
+++ b/www/styles.css
@@ -520,14 +520,6 @@ table.dataTable td, table.dataTable th { border-color: #eef1ec !important; color
   width: 100%; height: 100%; min-height: 460px; display: block;
   object-fit: cover; object-position: 62% 52%; filter: saturate(.98) contrast(1.03);
 }
-.smt-poster-art figcaption {
-  position: absolute; z-index: 2; right: 17px; bottom: 15px; left: 17px;
-  width: fit-content; max-width: calc(100% - 34px); padding: 8px 10px;
-  border: 1px solid rgba(243, 232, 203, .18); border-radius: 999px;
-  color: #f3e8cb; background: rgba(17, 21, 18, .9); font-size: 11px; line-height: 1.35;
-  text-align: right;
-}
-
 .picker-start { max-width: 760px; margin: 34px auto 8px; text-align: center; }
 .picker-start:focus-visible { outline: 3px solid var(--sky); outline-offset: 6px; border-radius: 8px; }
 .picker-start-kicker {


### PR DESCRIPTION
Removes the ornamental cover-art label from Pages and the in-app Living Poster while preserving descriptive alt text, durable image provenance, and scientific/data limitations. Also pins the manifest-producing workflow closure to the recorded `bslib@0.11.0` after the moving CRAN request correctly failed closed.

Validated regeneration run: #31067043557
Exact reviewed head: `c1b667b6d0cc2558853edfc6b1d505950bf27d9b`
Validated artifact: `small-mammal-manifest-promotion-d157872bf98201083719a4721d56f92ae8b79c3c`
Artifact digest: `sha256:ce2746818736f86f1452ba29c55446251dc1e2aba9d464cc148e8fa0b43c688d`
Manifest SHA-256: `858c028af411e35975c663111b18a6257e9d99a125b3a29715ee9221b986363b`
The manifest promotion is a direct child of the repaired source head.